### PR TITLE
refactor: nombrado expresivo, typedefs JSDoc y Howler.js en Audio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dexie": "^4.3.0",
+        "howler": "^2.2.4",
         "pixi.js": "^8.16.0"
       },
       "devDependencies": {
@@ -841,9 +842,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -984,6 +985,12 @@
         "js-binary-schema-parser": "^2.0.3"
       }
     },
+    "node_modules/howler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1046,9 +1053,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1215,9 +1222,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "dexie": "^4.3.0",
+    "howler": "^2.2.4",
     "pixi.js": "^8.16.0"
   }
 }

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -1,64 +1,177 @@
 // src/core/Engine.js
 
-import { Character } from './models/Character.js';
+import { Character }  from './models/Character.js';
+import { GameState }  from './State.js';
 
-// Ruta base del deployment — '/' en dev, '/Dramaturge/' en GitHub Pages
-const BASE_URL = import.meta.env.BASE_URL;
+// ─── Constantes ───────────────────────────────────────────────────────────────
 
-import { GameState } from './State.js';
+const DEPLOYMENT_BASE_URL      = import.meta.env.BASE_URL;
+const BACKLOG_MAX_ENTRIES      = 80;
+const AUTOSAVE_DEBOUNCE_MS     = 2500;
+const SKIP_ADVANCE_INTERVAL_MS = 30;
+const AUTO_ADVANCE_DEFAULT_MS  = 1800;
 
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {'left' | 'center' | 'right'} SpriteSlot
+ */
+
+/**
+ * @typedef {Object} BacklogEntry
+ * @property {string|null} speaker - Nombre del personaje o null si es narración
+ * @property {string}      text
+ */
+
+/**
+ * @typedef {Object} ParsedInstruction
+ * @property {string} type - Tipo de instrucción: 'DIALOGUE', 'NARRATE', 'GOTO', etc.
+ * @property {number} line - Línea original en el script .dan
+ */
+
+/**
+ * @typedef {Object} VisualSlotState
+ * @property {string} actorId
+ * @property {string} path
+ */
+
+/**
+ * @callback PuzzleResolver
+ * @param {string} puzzleId
+ * @returns {Promise<boolean>}
+ */
+
+/**
+ * @callback SceneLoader
+ * @param {string}      target
+ * @param {string|null} fadeColor
+ * @returns {Promise<void>}
+ */
+
+// ─── Engine ───────────────────────────────────────────────────────────────────
+
+/**
+ * Núcleo del motor de novela visual.
+ *
+ * Responsabilidades:
+ * - Ejecutar instrucciones parseadas del lenguaje Koedan en secuencia
+ * - Mantener el estado del juego sincronizado con el progreso narrativo
+ * - Gestionar los modos de lectura: normal, automático y skip
+ * - Coordinar renderer, audio y sistema de guardado
+ *
+ * Dependencias externas inyectadas tras instanciar:
+ * - `puzzleResolver` — abre puzzles y devuelve el resultado
+ * - `sceneLoader`    — carga y ejecuta otra escena .dan
+ *
+ * @example
+ * const engine = new Dramaturge(db, renderer, audio, state, saveManager);
+ * engine.puzzleResolver = (id) => puzzleSystem.open(id);
+ * engine.sceneLoader    = (target, fade) => sceneManager.goto(target, fade);
+ * await engine.loadScript(parsedInstructions);
+ * await engine.next();
+ */
 export class Dramaturge {
+
+    // ── Dependencias ───────────────────────────────────────────────────────
+
+    /** @type {import('dexie').Dexie} */
+    #db;
+
+    /** @type {import('../modules/Renderer.js').Renderer} */
+    renderer;
+
+    /** @type {import('../modules/Audio.js').AudioManager} */
+    audio;
+
+    /** @type {GameState} */
+    state;
+
+    /** @type {import('./SaveManager.js').SaveManager|null} */
+    #saveManager;
+
+    // ── Callbacks externos ─────────────────────────────────────────────────
+
+    /** @type {PuzzleResolver|null} */
+    puzzleResolver = null;
+
+    /** @type {SceneLoader|null} */
+    sceneLoader = null;
+
+    // ── Estado de ejecución ────────────────────────────────────────────────
+
+    /** @type {ParsedInstruction[]} */
+    instructions = [];
+
+    /** @type {number} — índice de la próxima instrucción a ejecutar */
+    currentIndex = 0;
+
+    /** @type {boolean} — true mientras el engine espera input del jugador */
+    isBlocked = false;
+
+    /** @type {'dialogue' | 'narrate' | null} — modo de textbox activo */
+    #lastRenderedTextMode = null;
+
+    // ── Personajes en escena ───────────────────────────────────────────────
+
+    /** @type {Map<string, Character>} — actores cargados en memoria por id */
+    #loadedCharacters = new Map();
+
+    /** @type {Record<SpriteSlot, string|null>} — actorId ocupando cada slot */
+    #occupiedSlots = { left: null, center: null, right: null };
+
+    // ── Backlog ────────────────────────────────────────────────────────────
+
+    /** @type {BacklogEntry[]} — historial de diálogos y narraciones, máx 80 */
+    backlog = [];
+
+    // ── Modos de lectura ───────────────────────────────────────────────────
+
+    /** @type {boolean} */
+    autoMode = false;
+
+    /** @type {boolean} */
+    skipMode = false;
+
+    /** @type {number} — ms entre avances en modo automático */
+    autoAdvanceDelayMs = AUTO_ADVANCE_DEFAULT_MS;
+
     /**
-     * @param {object}      db           - Instancia de Dexie
-     * @param {Renderer}  renderer     - Módulo de render
-     * @param {AudioManager}     audioManager - Módulo de audio
-     * @param {GameState}   state        - Estado del juego (crea uno nuevo si no se pasa)
-     * @param {SaveManager} saveManager  - Gestor de guardado (autosave desactivado si null)
+     * Índice más alto completado por el jugador en esta partida.
+     * El modo skip solo avanza hasta este punto — nunca más allá.
+     * @type {number}
      */
-    constructor(db, renderer, audioManager, state = null, saveManager = null) {
-        this.db          = db;
-        this.renderer    = renderer;
-        this.audio       = audioManager;
-        this.state       = state       ?? new GameState();
-        this.saveManager = saveManager ?? null;
+    highWaterMark = 0;
 
-        this.activePawns = new Map();
-        this.slots       = { left: null, center: null, right: null };
+    // ── Guards y timers ────────────────────────────────────────────────────
 
-        this.instructions = [];
-        this.currentIndex = 0;
-        this.isBlocked    = false;
-        this._lastTextMode = null; // 'narrate' | 'dialogue' | null — para detectar cambios de modo
+    /** @type {boolean} — previene re-entrancia en next() */
+    #isAdvancing = false;
 
-        // ── Modos de lectura ──────────────────────────────────────────────
-        // Auto: avanza solo cuando el typewriter termina (con delay)
-        // Skip: avanza instantáneamente, solo en líneas ya vistas
-        this.autoMode      = false;
-        this.skipMode      = false;
-        this.autoDelay     = 1800;  // ms entre líneas en modo auto (configurable)
-        this._autoTimer    = null;
-        // highWaterMark: índice más alto que el jugador ha completado.
-        // Suficiente para skip en historias lineales con finales por flags/inventario.
-        // No necesita ser un Set — ahorra memoria y escrituras en DB.
-        this.highWaterMark  = 0;
-        this._nextRunning   = false; // guard de re-entrancia para next()
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    #readingModeTimer = null;
 
-        // ── Backlog ───────────────────────────────────────────────────────
-        // Array de { speaker: string|null, text: string } — últimas 80 entradas.
-        // speaker es null para narraciones.
-        this.backlog = [];
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    #autosaveTimer = null;
 
-        // Callbacks externos — se inyectan después de instanciar el Engine.
-        //
-        // Firma: (puzzleId: string) => Promise<boolean>
-        // Inyectar: engine.puzzleResolver = (id) => puzzleSystem.open(id)
-        this.puzzleResolver = null;
+    /** @type {Function|null} — callback cuando el skip para automáticamente */
+    #onSkipStop = null;
 
-        // Firma: (target: string) => Promise<void>
-        // Inyectar: engine.sceneLoader = (t) => sceneManager.goto(t)
-        this.sceneLoader = null;
+    /** @type {number} — timestamp de inicio de sesión para calcular playTime */
+    #sessionStartTimestamp = Date.now();
 
-        this._sessionStart = Date.now();
+    /**
+     * @param {import('dexie').Dexie}                          db
+     * @param {import('../modules/Renderer.js').Renderer}      renderer
+     * @param {import('../modules/Audio.js').AudioManager}     audio
+     * @param {GameState}                                      state
+     * @param {import('./SaveManager.js').SaveManager|null}    saveManager
+     */
+    constructor(db, renderer, audio, state = null, saveManager = null) {
+        this.#db          = db;
+        this.renderer     = renderer;
+        this.audio        = audio;
+        this.state        = state       ?? new GameState();
+        this.#saveManager = saveManager ?? null;
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -66,104 +179,25 @@ export class Dramaturge {
     // ─────────────────────────────────────────────────────────────────────────
 
     /**
-     * Resetea el engine completamente para una partida nueva.
-     * Limpia: state narrativo, pawns, backlog, renderer visual, timers.
-     * Conserva: preferencias de audio (viven en state.audioSettings).
+     * Carga un array de instrucciones parseadas y reinicia el cursor de ejecución.
+     * @param {ParsedInstruction[]} parsedInstructions
      */
-    reset() {
-        // Estado narrativo
-        this.state.reset();
-        this.highWaterMark  = 0;
-        this.currentIndex   = 0;
-        this.instructions   = [];
-        this._lastTextMode  = null;
-        this._nextRunning   = false;
-
-        // Modos de lectura
-        this.autoMode = false;
-        this.skipMode = false;
-        clearTimeout(this._autoTimer);
-        this.renderer._instantText = false;
-        this._skipOnStop = null;
-
-        // Personajes instanciados
-        this.activePawns.clear();
-
-        // Backlog de la sesión
-        this.backlog = [];
-
-        // Renderer: limpiar escena visual
-        this.renderer.clearScene?.();
-
-        console.log('[Engine] Reset completo. Partida nueva.');
-    }
-
     async loadScript(parsedInstructions) {
         this.instructions = parsedInstructions;
         this.currentIndex = 0;
         console.log('[Engine] Script cargado. Instrucciones:', this.instructions.length);
     }
 
-    async resumeFromState(loadedState) {
-        this.state        = loadedState;
-        this.currentIndex = loadedState.currentIndex;
-        // Restaurar hasta dónde llegó el jugador (para skip)
-        this.highWaterMark = loadedState.highWaterMark ?? 0;
-
-        // ── Restaurar audio ───────────────────────────────────────────────
-        const { bgmVolume, sfxVolume, voiceVolume } = loadedState.audioSettings;
-        this.audio.setVolume('bgm',   bgmVolume);
-        this.audio.setVolume('se',    sfxVolume);
-        this.audio.setVolume('voice', voiceVolume);
-
-        // ── Restaurar estado visual (fondo + sprites) ─────────────────────
-        // Orden garantizado: fondo → sprites → modo de textbox
-        const vs = loadedState.visualState ?? {};
-
-        // 1. Fondo
-        if (vs.bg) {
-            await this.renderer.changeBackground(vs.bg, 'none');
-        }
-
-        // 2. Sprites (cargar pawn si no está activo y renderizar en su slot)
-        if (vs.sprites) {
-            for (const [slot, { actorId, path }] of Object.entries(vs.sprites)) {
-                if (!this.activePawns.has(actorId)) {
-                    const data = await this.db.characters.get(actorId);
-                    if (data) {
-                        const { Character } = await import('./models/Character.js');
-                        this.activePawns.set(actorId, new Character(data));
-                    }
-                }
-                this.slots[slot] = actorId;
-                await this.renderer.renderSprite(actorId, path, slot, 'none');
-            }
-        }
-
-        // 3. BGM activo al momento del guardado
-        if (vs.bgm?.track) {
-            await this.audio.playBGM(vs.bgm.track, vs.bgm.vol ?? 0.5);
-        }
-
-        // 4. Modo de textbox
-        if (vs.mode === 'narrate') {
-            this.renderer._setNarrationMode?.(true);
-            this._lastTextMode = 'narrate';
-        } else if (vs.mode === 'dialogue') {
-            this.renderer._setNarrationMode?.(false);
-            this._lastTextMode = 'dialogue';
-        }
-
-        console.log(`[Engine] Reanudando desde índice ${this.currentIndex}. Visual restaurado.`);
-    }
-
-    // next() público — punto de entrada para input del usuario.
-    // Guard de re-entrancia: si ya está corriendo, el clic extra se descarta.
-    // Las llamadas internas del engine usan _nextInternal() directamente.
+    /**
+     * Avanza el script un paso. Punto de entrada para todo input del jugador.
+     *
+     * Si el typewriter está activo: lo completa instantáneamente.
+     * Si el engine está bloqueado esperando input: no hace nada.
+     * Guard de re-entrancia: descarta llamadas mientras ya está avanzando.
+     */
     async next() {
-        if (this._nextRunning) return;
+        if (this.#isAdvancing) return;
 
-        // Si hay texto activo: skip o flash de feedback
         if (this.isBlocked) {
             if (this.renderer._skipLocked) {
                 this.renderer.flashTextBox?.();
@@ -174,514 +208,685 @@ export class Dramaturge {
             return;
         }
 
-        this._nextRunning = true;
+        this.#isAdvancing = true;
         try {
-            await this._nextInternal();
+            await this.#advance();
         } finally {
-            this._nextRunning = false;
+            this.#isAdvancing = false;
         }
     }
 
-    // _nextInternal() — avance real del script.
-    // Se llama recursivamente desde execute() para instrucciones no-bloqueantes.
-    async _nextInternal() {
+    /**
+     * Restaura el engine desde un GameState guardado.
+     * Reconstruye el estado visual (fondo, sprites, modo) y de audio.
+     * @param {GameState} savedState
+     */
+    async resumeFromState(savedState) {
+        this.state         = savedState;
+        this.currentIndex  = savedState.currentIndex;
+        this.highWaterMark = savedState.highWaterMark ?? 0;
 
-        if (this.currentIndex >= this.instructions.length) {
-            console.log('[Engine] Fin del script.');
-            return;
-        }
+        this.#restoreAudioVolumes(savedState.audioSettings);
+        await this.#restoreVisualState(savedState.visualState ?? {});
 
-        const inst = this.instructions[this.currentIndex];
-        this.currentIndex++;
-
-        // Skip mode: si esta instrucción ya fue vista, el typewriter será instantáneo
-        // (renderer._instantText = true). _syncStateAndSave lo relanzará automáticamente.
-        if (this.skipMode && (this.currentIndex - 1) <= this.highWaterMark) {
-            const isText = inst.type === 'DIALOGUE' || inst.type === 'NARRATE';
-            if (isText) this.renderer._instantText = true;
-        }
-
-        await this.execute(inst);
+        console.log(`[Engine] Reanudando desde índice ${this.currentIndex}. Visual restaurado.`);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // DESPACHADOR CENTRAL
-    // ─────────────────────────────────────────────────────────────────────────
+    /**
+     * Resetea el engine completamente para iniciar una partida nueva.
+     * Preserva las preferencias de audio del jugador.
+     */
+    reset() {
+        this.state.reset();
+        this.instructions          = [];
+        this.currentIndex          = 0;
+        this.highWaterMark         = 0;
+        this.isBlocked             = false;
+        this.#lastRenderedTextMode = null;
+        this.#isAdvancing          = false;
+        this.autoMode              = false;
+        this.skipMode              = false;
+        this.#onSkipStop           = null;
+        this.backlog               = [];
 
+        clearTimeout(this.#readingModeTimer);
+        this.renderer._instantText = false;
+        this.#loadedCharacters.clear();
+        this.#occupiedSlots = { left: null, center: null, right: null };
+        this.renderer.clearScene?.();
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // DESPACHADOR CENTRAL
-    // ─────────────────────────────────────────────────────────────────────────
-
-    async execute(inst) {
-        switch (inst.type) {
-
-            // ── Personajes ────────────────────────────────────────────────────
-
-            case 'PAWN_LOAD': {
-                for (const id of inst.names) {
-                    if (this.activePawns.has(id)) continue;
-                    const data = await this.db.characters.get(id);
-                    if (data) {
-                        this.activePawns.set(id, new Character(data));
-                        console.log(`[Engine] Pawn "${id}" instanciado.`);
-                    } else {
-                        console.error(`[Engine] ERROR: personaje "${id}" no existe en la DB.`);
-                    }
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            case 'SPRITE_SHOW': {
-                const pawn = this.activePawns.get(inst.actor);
-                if (!pawn) {
-                    console.error(`[Engine] SPRITE_SHOW: pawn "${inst.actor}" no cargado.`);
-                    break;
-                }
-                const path = `${BASE_URL}${pawn.getSprite(inst.pose).replace(/^\//, '')}`;
-                this._clearActorFromSlots(inst.actor);
-                this.slots[inst.slot] = inst.actor;
-                await this.renderer.renderSprite(inst.actor, path, inst.slot, inst.effect);
-                // Persistir sprite activo para restaurar al cargar
-                this.state.visualState.sprites[inst.slot] = { actorId: inst.actor, path };
-                await this._nextInternal();
-                break;
-            }
-
-            case 'SPRITE_HIDE': {
-                const slot = this._getActorSlot(inst.actor);
-                if (slot) {
-                    await this.renderer.hideSprite(inst.actor, slot, inst.effect);
-                    this.slots[slot] = null;
-                    delete this.state.visualState.sprites[slot]; // ← limpiar del state
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            // ── Escena y audio ─────────────────────────────────────────────────
-
-            case 'BG_CHANGE': {
-                await this.renderer.changeBackground(inst.target, inst.effect, inst.time);
-                this.state.visualState.bg = inst.target; // ← persistir fondo activo
-                await this._nextInternal();
-                break;
-            }
-
-            case 'AUDIO': {
-                if (inst.audioType === 'bgm') {
-                    const bgmVolume = parseFloat(inst.vol ?? 0.5);
-                    this.audio.playBGM(inst.param, bgmVolume);
-                    this.state.visualState.bgm = { track: inst.param, vol: bgmVolume };
-                } else if (inst.audioType === 'se') {
-                    this.audio.playSE(inst.param, parseFloat(inst.vol ?? 0.8));
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            // ── Diálogo y narración ────────────────────────────────────────────
-
-            case 'DIALOGUE': {
-                const pawn = this.activePawns.get(inst.actor);
-
-                // Transición de modo si veníamos de narración
-                // modeTransition bloquea con overlay blanco mientras el modo cambia
-                if (this._lastTextMode === 'narrate') {
-                    await this.renderer.modeTransition(false);
-                }
-                this._lastTextMode = 'dialogue';
-                this.state.visualState.mode = 'dialogue';
-
-                if (inst.pose && pawn) {
-                    const posePath  = `${BASE_URL}${pawn.getSprite(inst.pose).replace(/^\//, '')}`;
-                    const actorSlot = this._getActorSlot(inst.actor);
-                    if (actorSlot) this.renderer.updateSprite(inst.actor, posePath, actorSlot);
-                }
-
-                if (inst.vo && pawn) {
-                    this.audio.playVoice(`${pawn.voicePrefix}${inst.vo}.mp3`);
-                }
-
-                this.isBlocked    = true;
-                const speakerName = pawn ? pawn.name : inst.actor;
-
-                // Añadir al backlog (máx 80 entradas — FIFO)
-                this.backlog.push({ speaker: speakerName, text: inst.text });
-                if (this.backlog.length > 80) this.backlog.shift();
-
-                await this.renderer.typewriter(speakerName, inst.text, () => {
-                    this.isBlocked = false;
-                    this._syncStateAndSave();
-                });
-                break;
-            }
-
-            case 'NARRATE': {
-                // Transición de modo si veníamos de diálogo normal
-                if (this._lastTextMode === 'dialogue') {
-                    await this.renderer.modeTransition(true);
-                }
-                this.state.visualState.mode = 'narrate';
-
-                this.isBlocked = true;
-
-                // Añadir al backlog
-                this.backlog.push({ speaker: null, text: inst.text });
-                if (this.backlog.length > 80) this.backlog.shift();
-
-                await this.renderer.typewriter(null, inst.text, () => {
-                    this.isBlocked = false;
-                    this._syncStateAndSave();
-                });
-                break;
-            }
-
-            // ── Control de flujo ───────────────────────────────────────────────
-
-            case 'WAIT': {
-                // En skip mode no esperamos — el jugador ya vio esta escena
-                if (!this.skipMode) {
-                    const ms = this._parseDuration(inst.duration);
-                    this.isBlocked = true;
-                    await new Promise(resolve => setTimeout(resolve, ms));
-                    this.isBlocked = false;
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            case 'PUZZLE': {
-                this.isBlocked = true;
-
-                let passed = false;
-                if (this.puzzleResolver) {
-                    passed = await this.puzzleResolver(inst.puzzleId);
-                } else {
-                    console.warn(`[Engine] Puzzle "${inst.puzzleId}": no hay puzzleResolver. Asumiendo fallo.`);
-                }
-
-                // Actualizar contadores en el state
-                this.state.setFlag(`${inst.puzzleId}_result`, String(passed));
-                const solved = this.state.getFlag('puzzles_solved', 0) ?? 0;
-                const failed = this.state.getFlag('puzzles_failed', 0) ?? 0;
-                if (passed) {
-                    this.state.setFlag('puzzles_solved', String(Number(solved) + 1));
-                } else {
-                    this.state.setFlag('puzzles_failed', String(Number(failed) + 1));
-                }
-
-                console.log(`[Engine] Puzzle "${inst.puzzleId}" → ${passed ? 'PASS' : 'FAIL'}`);
-
-                // Mostrar resultado como narración — desbloquea al hacer clic
-                const resultText = passed ? inst.passText : inst.failText;
-                // El resultado del puzzle usa modo narrador
-                this.state.visualState.mode = 'narrate';
-
-                await this.renderer.typewriter(null, resultText, () => {
-                    this.isBlocked = false;
-                    this._syncStateAndSave();
-                });
-                break;
-            }
-
-            case 'GOTO': {
-                this._syncState();
-
-                if (!this.sceneLoader) {
-                    this.state.currentFile = `${inst.target}.dan`;
-                    console.log(`[Engine] GOTO → "${inst.target}.dan". Sin SceneManager: detenido.`);
-                    break;
-                }
-
-                if (inst.transition && this.renderer?.sceneTransition) {
-                    // Fase 1: fade IN (oscurece la pantalla, ~480ms)
-                    // Cargamos la escena mientras la pantalla está oscura/blanca
-                    // para que el jugador nunca vea el swap de assets.
-                    const halfMs = 480;
-                    this.renderer.sceneTransition(inst.transition, halfMs); // no await — corre en paralelo
-                    await new Promise(r => setTimeout(r, halfMs));          // esperar que tape la pantalla
-                    await this.sceneLoader(inst.target);                    // cargar nueva escena
-                    // Fase 2: el fade OUT lo completa sceneTransition internamente
-                } else {
-                    await this.sceneLoader(inst.target);
-                }
-                break;
-            }
-
-            // ── Estado ─────────────────────────────────────────────────────────
-
-            case 'SET_FLAG': {
-                this.state.setFlag(inst.key, inst.value);
-                console.log(`[Engine] Flag "${inst.key}" = ${inst.value}`);
-                await this._nextInternal();
-                break;
-            }
-
-            case 'INVENTORY_ADD': {
-                this.state.addItem(inst.item);
-                console.log(`[Engine] Inventario: añadido "${inst.item}".`);
-                await this._nextInternal();
-                break;
-            }
-
-            case 'INVENTORY_REMOVE': {
-                this.state.removeItem(inst.item);
-                console.log(`[Engine] Inventario: eliminado "${inst.item}".`);
-                await this._nextInternal();
-                break;
-            }
-
-            case 'UNLOCK': {
-                // Meta-progreso — no vive en GameState sino en db.gallery directamente.
-                // Sobrevive a Nueva Partida y a borrar saves.
-                const existing = await this.db.gallery?.get(inst.cgId);
-                if (!existing) {
-                    const path = `${BASE_URL}assets/cg/${inst.cgId}`;
-                    await this.db.gallery?.put({
-                        id:          inst.cgId,
-                        title:       inst.title ?? inst.cgId,
-                        path,
-                        unlockedAt:  Date.now(),
-                    });
-                    console.log(`[Engine] CG desbloqueado: "${inst.cgId}"`);
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            // ── Condicionales ──────────────────────────────────────────────────────
-
-            case 'COND_JUMP': {
-                // Evaluar la condición — si es FALSA, saltar a targetIndex
-                const passes = this._evalCondition(inst.condition);
-                if (!passes) {
-                    this.currentIndex = inst.targetIndex;
-                }
-                await this._nextInternal();
-                break;
-            }
-
-            case 'JUMP': {
-                // Salto incondicional (generado por el bloque else)
-                this.currentIndex = inst.targetIndex;
-                await this._nextInternal();
-                break;
-            }
-
-            default: {
-                console.warn(`[Engine] Instrucción no reconocida: "${inst.type}". Saltando.`);
-                await this._nextInternal();
-            }
-        }
+        console.log('[Engine] Reset completo. Partida nueva.');
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // MODOS DE LECTURA
-    // ─────────────────────────────────────────────────────────────────────────
-
-    toggleAuto() {
+    /**
+     * Activa o desactiva el modo automático.
+     * Mutuamente excluyente con skipMode.
+     * @returns {boolean} — estado resultante del modo auto
+     */
+    toggleAutoMode() {
         this.autoMode = !this.autoMode;
-        this.skipMode = false; // mutuamente excluyentes
-        if (!this.autoMode) clearTimeout(this._autoTimer);
-        console.log(`[Engine] Auto: ${this.autoMode ? 'ON' : 'OFF'}`);
+        this.skipMode = false;
+        if (!this.autoMode) clearTimeout(this.#readingModeTimer);
         return this.autoMode;
     }
 
     /**
-     * Inicia el skip: avanza instantáneamente hasta el primer texto no visto.
-     * Se detiene solo cuando currentIndex > highWaterMark o llega al fin.
-     * Si skip ya está activo, lo cancela (permite abortar con un segundo toque).
+     * Inicia el modo skip si hay progreso previo, o lo cancela si ya estaba activo.
+     * El skip avanza instantáneamente hasta el primer contenido no visto.
      *
-     * @param {Function} [onStop] - Callback cuando el skip para (botón → off)
+     * @param {Function} [onStop] — llamado cuando el skip para (por límite o cancelación)
+     * @returns {boolean} — true si el skip arrancó, false si se canceló o no hay historial
      */
-    triggerSkip(onStop) {
+    triggerSkipMode(onStop) {
         if (this.skipMode) {
-            // Segundo toque — cancelar skip en curso
-            this.skipMode = false;
-            clearTimeout(this._autoTimer);
-            this.renderer._instantText = false;
+            this.#cancelSkipMode();
             onStop?.();
             return false;
         }
 
         if (this.highWaterMark === 0) {
-            // Sin historial — no hay nada que skipear
             onStop?.();
             return false;
         }
 
-        this.skipMode  = true;
-        this.autoMode  = false;
-        this._skipOnStop = onStop; // guardado para cuando el skip para solo
+        this.skipMode    = true;
+        this.autoMode    = false;
+        this.#onSkipStop = onStop;
 
         if (!this.isBlocked) this.next();
         return true;
     }
 
-    /** Llamado internamente cuando el skip llega al final de lo ya visto */
-    _stopSkip() {
-        if (!this.skipMode) return;
-        this.skipMode = false;
-        this.renderer._instantText = false;
-        clearTimeout(this._autoTimer);
-        this._skipOnStop?.();
-        this._skipOnStop = null;
-    }
-
-    stopModes() {
+    /**
+     * Detiene todos los modos de lectura activos y fuerza un autosave inmediato.
+     * Llamar al abrir el menú de pausa.
+     */
+    stopAllReadingModes() {
         this.autoMode = false;
         this.skipMode = false;
-        clearTimeout(this._autoTimer);
-        // Forzar flush del autosave pendiente al detener modos
-        clearTimeout(this._autosaveTimer);
-        if (this.saveManager && this.state) {
-            this.saveManager.save(this.state, 'autosave')
-                .catch(err => console.error('[Engine] Autosave flush falló:', err));
+        clearTimeout(this.#readingModeTimer);
+        clearTimeout(this.#autosaveTimer);
+
+        if (this.#saveManager && this.state) {
+            this.#saveManager.save(this.state, 'autosave')
+                .catch(err => console.error('[Engine] Autosave urgente falló:', err));
+        }
+    }
+
+    // ── Save / Load ────────────────────────────────────────────────────────
+
+    /** @param {string} slotId */
+    async saveToSlot(slotId = 'slot_1') {
+        if (!this.#saveManager) {
+            console.warn('[Engine] saveToSlot: no hay SaveManager.');
+            return;
+        }
+        this.#syncStateSnapshot();
+        await this.#saveManager.save(this.state, slotId);
+    }
+
+    /** @param {string} slotId */
+    async loadFromSlot(slotId = 'slot_1') {
+        if (!this.#saveManager) return;
+        const savedState = await this.#saveManager.load(slotId);
+        if (savedState) await this.resumeFromState(savedState);
+    }
+
+    exportSaveToFile() {
+        if (!this.#saveManager) return;
+        this.#syncStateSnapshot();
+        this.#saveManager.exportToFile(this.state);
+    }
+
+    async importSaveFromFile() {
+        if (!this.#saveManager) return;
+        const importedState = await this.#saveManager.importFromFile();
+        if (importedState) await this.resumeFromState(importedState);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DESPACHADOR DE INSTRUCCIONES
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Ejecuta una instrucción Koedan y avanza automáticamente si no bloquea.
+     * Cada case es responsable de llamar `#advance()` o bloquear el engine.
+     * @param {ParsedInstruction} instruction
+     */
+    async #dispatch(instruction) {
+        switch (instruction.type) {
+
+            // ── Personajes ─────────────────────────────────────────────────
+
+            case 'PAWN_LOAD': {
+                await this.#loadCharactersIntoMemory(instruction.names);
+                await this.#advance();
+                break;
+            }
+
+            case 'SPRITE_SHOW': {
+                await this.#showCharacterSprite(instruction);
+                await this.#advance();
+                break;
+            }
+
+            case 'SPRITE_HIDE': {
+                await this.#hideCharacterSprite(instruction);
+                await this.#advance();
+                break;
+            }
+
+            // ── Escena y audio ─────────────────────────────────────────────
+
+            case 'BG_CHANGE': {
+                await this.renderer.changeBackground(instruction.target, instruction.effect, instruction.time);
+                this.state.visualState.bg = instruction.target;
+                await this.#advance();
+                break;
+            }
+
+            case 'AUDIO': {
+                await this.#handleAudioInstruction(instruction);
+                await this.#advance();
+                break;
+            }
+
+            // ── Diálogo y narración ────────────────────────────────────────
+
+            case 'DIALOGUE': {
+                await this.#renderDialogueLine(instruction);
+                break;
+            }
+
+            case 'NARRATE': {
+                await this.#renderNarrationLine(instruction);
+                break;
+            }
+
+            // ── Control de flujo ───────────────────────────────────────────
+
+            case 'WAIT': {
+                await this.#waitIfNotSkipping(instruction.duration);
+                await this.#advance();
+                break;
+            }
+
+            case 'PUZZLE': {
+                await this.#openAndResolvePuzzle(instruction);
+                break;
+            }
+
+            case 'GOTO': {
+                await this.#navigateToScene(instruction);
+                break;
+            }
+
+            // ── Efectos de pantalla ────────────────────────────────────────
+
+            case 'FX_SHAKE': {
+                await this.renderer.fxShake(this.#parseDurationToMs(instruction.duration));
+                await this.#advance();
+                break;
+            }
+
+            case 'FX_FLASH': {
+                await this.renderer.fxFlash(instruction.color, this.#parseDurationToMs(instruction.duration));
+                await this.#advance();
+                break;
+            }
+
+            case 'FX_VIGNETTE': {
+                this.renderer.fxVignette(instruction.state === 'on');
+                await this.#advance();
+                break;
+            }
+
+            // ── Estado del juego ───────────────────────────────────────────
+
+            case 'SET_FLAG': {
+                this.state.setFlag(instruction.key, instruction.value);
+                await this.#advance();
+                break;
+            }
+
+            case 'INVENTORY_ADD': {
+                this.state.addItem(instruction.item);
+                await this.#advance();
+                break;
+            }
+
+            case 'INVENTORY_REMOVE': {
+                this.state.removeItem(instruction.item);
+                await this.#advance();
+                break;
+            }
+
+            case 'UNLOCK': {
+                await this.#unlockGalleryCg(instruction);
+                await this.#advance();
+                break;
+            }
+
+            // ── Condicionales ──────────────────────────────────────────────
+
+            case 'COND_JUMP': {
+                const conditionPasses = this.#evaluateCondition(instruction.condition);
+                if (!conditionPasses) this.currentIndex = instruction.targetIndex;
+                await this.#advance();
+                break;
+            }
+
+            case 'JUMP': {
+                this.currentIndex = instruction.targetIndex;
+                await this.#advance();
+                break;
+            }
+
+            default: {
+                console.warn(`[Engine] Instrucción desconocida: "${instruction.type}". Saltando.`);
+                await this.#advance();
+            }
         }
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // SAVE / LOAD
+    // AVANCE INTERNO
     // ─────────────────────────────────────────────────────────────────────────
 
-    async saveToSlot(slotId = 'slot_1') {
-        if (!this.saveManager) { console.warn('[Engine] No hay SaveManager.'); return; }
-        this._syncState();
-        await this.saveManager.save(this.state, slotId);
+    async #advance() {
+        if (this.currentIndex >= this.instructions.length) {
+            console.log('[Engine] Fin del script.');
+            return;
+        }
+
+        const currentInstruction = this.instructions[this.currentIndex];
+        this.currentIndex++;
+
+        this.#activateInstantTextIfSkipping(currentInstruction);
+        await this.#dispatch(currentInstruction);
     }
 
-    async loadFromSlot(slotId = 'slot_1') {
-        if (!this.saveManager) return;
-        const loaded = await this.saveManager.load(slotId);
-        if (loaded) await this.resumeFromState(loaded);
-    }
+    /** @param {ParsedInstruction} instruction */
+    #activateInstantTextIfSkipping(instruction) {
+        const isTextInstruction = instruction.type === 'DIALOGUE' || instruction.type === 'NARRATE';
+        const isAlreadySeen     = (this.currentIndex - 1) <= this.highWaterMark;
 
-    exportSave() {
-        if (!this.saveManager) return;
-        this._syncState();
-        this.saveManager.exportToFile(this.state);
-    }
-
-    async importSave() {
-        if (!this.saveManager) return;
-        const loaded = await this.saveManager.importFromFile();
-        if (loaded) await this.resumeFromState(loaded);
+        if (this.skipMode && isTextInstruction && isAlreadySeen) {
+            this.renderer._instantText = true;
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // HELPERS PRIVADOS
+    // HANDLERS DE INSTRUCCIONES
     // ─────────────────────────────────────────────────────────────────────────
+
+    /** @param {string[]} characterIds */
+    async #loadCharactersIntoMemory(characterIds) {
+        for (const characterId of characterIds) {
+            if (this.#loadedCharacters.has(characterId)) continue;
+            const characterData = await this.#db.characters.get(characterId);
+            if (characterData) {
+                this.#loadedCharacters.set(characterId, new Character(characterData));
+                console.log(`[Engine] Personaje "${characterId}" cargado.`);
+            } else {
+                console.error(`[Engine] Personaje "${characterId}" no encontrado en DB.`);
+            }
+        }
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #showCharacterSprite(instruction) {
+        const character = this.#loadedCharacters.get(instruction.actor);
+        if (!character) {
+            console.error(`[Engine] SPRITE_SHOW: "${instruction.actor}" no está cargado.`);
+            return;
+        }
+        const spritePath = this.#buildAssetUrl(character.getSprite(instruction.pose));
+        this.#removeCharacterFromOccupiedSlots(instruction.actor);
+        this.#occupiedSlots[instruction.slot] = instruction.actor;
+        await this.renderer.renderSprite(instruction.actor, spritePath, instruction.slot, instruction.effect);
+        this.state.visualState.sprites[instruction.slot] = { actorId: instruction.actor, path: spritePath };
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #hideCharacterSprite(instruction) {
+        const occupiedSlot = this.#findSlotOccupiedByCharacter(instruction.actor);
+        if (!occupiedSlot) return;
+        await this.renderer.hideSprite(instruction.actor, occupiedSlot, instruction.effect);
+        this.#occupiedSlots[occupiedSlot] = null;
+        delete this.state.visualState.sprites[occupiedSlot];
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #handleAudioInstruction(instruction) {
+        if (instruction.audioType === 'bgm') {
+            const bgmVolume = parseFloat(instruction.vol ?? 0.5);
+            this.audio.playBGM(instruction.param, bgmVolume);
+            this.state.visualState.bgm = { track: instruction.param, vol: bgmVolume };
+        } else if (instruction.audioType === 'se') {
+            this.audio.playSE(instruction.param, parseFloat(instruction.vol ?? 0.8));
+        }
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #renderDialogueLine(instruction) {
+        const character = this.#loadedCharacters.get(instruction.actor);
+
+        if (this.#lastRenderedTextMode === 'narrate') {
+            await this.renderer.modeTransition(false);
+        }
+        this.#lastRenderedTextMode  = 'dialogue';
+        this.state.visualState.mode = 'dialogue';
+
+        if (instruction.pose && character) {
+            const posePath   = this.#buildAssetUrl(character.getSprite(instruction.pose));
+            const activeSlot = this.#findSlotOccupiedByCharacter(instruction.actor);
+            if (activeSlot) this.renderer.updateSprite(instruction.actor, posePath, activeSlot);
+        }
+
+        if (instruction.vo && character) {
+            this.audio.playVoice(`${character.voicePrefix}${instruction.vo}.mp3`);
+        }
+
+        const speakerName = character ? character.name : instruction.actor;
+        this.#pushToBacklog({ speaker: speakerName, text: instruction.text });
+
+        this.isBlocked = true;
+        await this.renderer.typewriter(speakerName, instruction.text, () => {
+            this.isBlocked = false;
+            this.#syncStateAndScheduleAutosave();
+        });
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #renderNarrationLine(instruction) {
+        if (this.#lastRenderedTextMode === 'dialogue') {
+            await this.renderer.modeTransition(true);
+        }
+        this.state.visualState.mode = 'narrate';
+        this.#pushToBacklog({ speaker: null, text: instruction.text });
+
+        this.isBlocked = true;
+        await this.renderer.typewriter(null, instruction.text, () => {
+            this.isBlocked = false;
+            this.#syncStateAndScheduleAutosave();
+        });
+    }
+
+    /** @param {string} duration */
+    async #waitIfNotSkipping(duration) {
+        if (this.skipMode) return;
+        const waitMs = this.#parseDurationToMs(duration);
+        this.isBlocked = true;
+        await new Promise(resolve => setTimeout(resolve, waitMs));
+        this.isBlocked = false;
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #openAndResolvePuzzle(instruction) {
+        this.isBlocked = true;
+
+        let puzzlePassed = false;
+        if (this.puzzleResolver) {
+            puzzlePassed = await this.puzzleResolver(instruction.puzzleId);
+        } else {
+            console.warn(`[Engine] Puzzle "${instruction.puzzleId}": puzzleResolver no inyectado.`);
+        }
+
+        this.state.setFlag(`${instruction.puzzleId}_result`, String(puzzlePassed));
+        this.#incrementPuzzleCounter(puzzlePassed);
+        console.log(`[Engine] Puzzle "${instruction.puzzleId}" → ${puzzlePassed ? 'PASS' : 'FAIL'}`);
+
+        const resultNarration       = puzzlePassed ? instruction.passText : instruction.failText;
+        this.state.visualState.mode = 'narrate';
+
+        await this.renderer.typewriter(null, resultNarration, () => {
+            this.isBlocked = false;
+            this.#syncStateAndScheduleAutosave();
+        });
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #navigateToScene(instruction) {
+        this.#syncStateSnapshot();
+        if (!this.sceneLoader) {
+            this.state.currentFile = `${instruction.target}.dan`;
+            console.log(`[Engine] GOTO "${instruction.target}": sceneLoader no inyectado.`);
+            return;
+        }
+        await this.sceneLoader(instruction.target, instruction.fadeColor ?? null);
+    }
+
+    /** @param {ParsedInstruction} instruction */
+    async #unlockGalleryCg(instruction) {
+        const alreadyUnlocked = await this.#db.gallery?.get(instruction.cgId);
+        if (alreadyUnlocked) return;
+        const cgPath = `${DEPLOYMENT_BASE_URL}assets/cg/${instruction.cgId}`;
+        await this.#db.gallery?.put({
+            id:         instruction.cgId,
+            title:      instruction.title ?? instruction.cgId,
+            path:       cgPath,
+            unlockedAt: Date.now(),
+        });
+        console.log(`[Engine] CG desbloqueado: "${instruction.cgId}"`);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MODO SKIP
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #cancelSkipMode() {
+        this.skipMode              = false;
+        this.renderer._instantText = false;
+        clearTimeout(this.#readingModeTimer);
+        this.#onSkipStop?.();
+        this.#onSkipStop = null;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SINCRONIZACIÓN DE ESTADO Y AUTOSAVE
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #syncStateAndScheduleAutosave() {
+        const completedIndex = this.currentIndex - 1;
+        if (completedIndex > this.highWaterMark) {
+            this.highWaterMark = completedIndex;
+        }
+        this.#syncStateSnapshot();
+        this.#scheduleAutosave();
+        this.#scheduleNextAdvanceIfReadingMode();
+    }
+
+    #syncStateSnapshot() {
+        this.state.currentIndex  = this.currentIndex;
+        this.state.highWaterMark = this.highWaterMark;
+        this.state.playTime     += Math.floor((Date.now() - this.#sessionStartTimestamp) / 1000);
+        this.#sessionStartTimestamp = Date.now();
+    }
+
+    #scheduleAutosave() {
+        if (!this.#saveManager) return;
+        clearTimeout(this.#autosaveTimer);
+        this.#autosaveTimer = setTimeout(() => {
+            this.#saveManager.save(this.state, 'autosave')
+                .catch(err => console.error('[Engine] Autosave falló:', err));
+        }, AUTOSAVE_DEBOUNCE_MS);
+    }
+
+    #scheduleNextAdvanceIfReadingMode() {
+        if (this.autoMode) {
+            clearTimeout(this.#readingModeTimer);
+            this.#readingModeTimer = setTimeout(() => {
+                if (this.autoMode && !this.isBlocked) this.next();
+            }, this.autoAdvanceDelayMs);
+
+        } else if (this.skipMode) {
+            const stillHasSeenContent = this.currentIndex <= this.highWaterMark;
+            if (stillHasSeenContent) {
+                clearTimeout(this.#readingModeTimer);
+                this.#readingModeTimer = setTimeout(() => {
+                    if (!this.skipMode || this.#isAdvancing) return;
+                    this.#isAdvancing = true;
+                    this.#advance().finally(() => { this.#isAdvancing = false; });
+                }, SKIP_ADVANCE_INTERVAL_MS);
+            } else {
+                this.#cancelSkipMode();
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RESTAURACIÓN DE ESTADO AL CARGAR
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** @param {{ bgmVolume: number, sfxVolume: number, voiceVolume: number }} audioSettings */
+    #restoreAudioVolumes(audioSettings) {
+        this.audio.setVolume('bgm',   audioSettings.bgmVolume);
+        this.audio.setVolume('se',    audioSettings.sfxVolume);
+        this.audio.setVolume('voice', audioSettings.voiceVolume);
+    }
+
+    /** @param {object} visualState */
+    async #restoreVisualState(visualState) {
+        if (visualState.bg) {
+            await this.renderer.changeBackground(visualState.bg, 'none');
+        }
+        if (visualState.sprites) {
+            await this.#restoreActiveSprites(visualState.sprites);
+        }
+        if (visualState.bgm?.track) {
+            await this.audio.playBGM(visualState.bgm.track, visualState.bgm.vol ?? 0.5);
+        }
+        if (visualState.mode === 'narrate') {
+            this.renderer._setNarrationMode?.(true);
+            this.#lastRenderedTextMode = 'narrate';
+        } else if (visualState.mode === 'dialogue') {
+            this.renderer._setNarrationMode?.(false);
+            this.#lastRenderedTextMode = 'dialogue';
+        }
+    }
+
+    /** @param {Record<SpriteSlot, VisualSlotState>} savedSprites */
+    async #restoreActiveSprites(savedSprites) {
+        for (const [slot, { actorId, path }] of Object.entries(savedSprites)) {
+            if (!this.#loadedCharacters.has(actorId)) {
+                const characterData = await this.#db.characters.get(actorId);
+                if (characterData) {
+                    this.#loadedCharacters.set(actorId, new Character(characterData));
+                }
+            }
+            this.#occupiedSlots[slot] = actorId;
+            await this.renderer.renderSprite(actorId, path, slot, 'none');
+        }
+    }
 
     // ─────────────────────────────────────────────────────────────────────────
     // EVALUADOR DE CONDICIONES
     // ─────────────────────────────────────────────────────────────────────────
 
     /**
-     * Evalúa una condición compilada por el Parser.
-     * @param   {object} cond - instrucción IF_FLAG o IF_INVENTORY original
+     * @param {ParsedInstruction} condition
      * @returns {boolean}
      */
-    _evalCondition(cond) {
-        if (cond.type === 'IF_INVENTORY') {
-            return this.state.hasItem(cond.item);
+    #evaluateCondition(condition) {
+        if (condition.type === 'IF_INVENTORY') {
+            return this.state.hasItem(condition.item);
         }
 
-        if (cond.type === 'IF_FLAG') {
-            const raw     = this.state.getFlag(cond.key, null);
-            const current = this._coerce(raw);
-            const target  = this._coerce(cond.value);
-            const op      = cond.op;
+        if (condition.type === 'IF_FLAG') {
+            const storedValue   = this.#coerceToNativeType(this.state.getFlag(condition.key, null));
+            const expectedValue = this.#coerceToNativeType(condition.value);
 
-            switch (op) {
-                case '==': return current == target;
-                case '!=': return current != target;
-                case '>':  return Number(current) >  Number(target);
-                case '<':  return Number(current) <  Number(target);
-                case '>=': return Number(current) >= Number(target);
-                case '<=': return Number(current) <= Number(target);
+            switch (condition.op) {
+                case '==': return storedValue == expectedValue;
+                case '!=': return storedValue != expectedValue;
+                case '>':  return Number(storedValue) >  Number(expectedValue);
+                case '<':  return Number(storedValue) <  Number(expectedValue);
+                case '>=': return Number(storedValue) >= Number(expectedValue);
+                case '<=': return Number(storedValue) <= Number(expectedValue);
                 default:
-                    console.warn(`[Engine] Operador desconocido: "${op}"`);
+                    console.warn(`[Engine] Operador desconocido: "${condition.op}"`);
                     return false;
             }
         }
 
-        console.warn(`[Engine] Tipo de condición desconocido: "${cond.type}"`);
+        console.warn(`[Engine] Tipo de condición desconocido: "${condition.type}"`);
         return false;
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // UTILIDADES PRIVADAS
+    // ─────────────────────────────────────────────────────────────────────────
+
     /**
-     * Convierte strings a sus tipos nativos para comparación.
-     * 'true'/'false' → boolean, números → number, resto → string.
+     * Convierte un string a su tipo nativo para comparaciones de condiciones.
+     * @param {*} rawValue
+     * @returns {boolean|number|string}
      */
-    _coerce(val) {
-        if (val === 'true')  return true;
-        if (val === 'false') return false;
-        const n = Number(val);
-        return isNaN(n) ? val : n;
+    #coerceToNativeType(rawValue) {
+        if (rawValue === 'true')  return true;
+        if (rawValue === 'false') return false;
+        const asNumber = Number(rawValue);
+        return isNaN(asNumber) ? rawValue : asNumber;
     }
 
-    _syncState() {
-        this.state.currentIndex = this.currentIndex;
-        this.state.playTime    += Math.floor((Date.now() - this._sessionStart) / 1000);
-        this._sessionStart      = Date.now();
-        this.state.highWaterMark = this.highWaterMark;
+    /**
+     * @param {string} durationString — '2s', '500ms', '1.5s'
+     * @returns {number}
+     */
+    #parseDurationToMs(durationString) {
+        if (durationString.endsWith('ms')) return parseInt(durationString);
+        return Math.round(parseFloat(durationString) * 1000);
     }
 
-    _syncStateAndSave() {
-        // Avanzar el marcador de progreso
-        if (this.currentIndex - 1 > this.highWaterMark)
-            this.highWaterMark = this.currentIndex - 1;
-        this._syncState();
-
-        // Autosave con debounce — cancela la escritura anterior si llega otra
-        // antes de 2.5s. Evita microfreezes en hardware lento por writes continuos.
-        if (this.saveManager) {
-            clearTimeout(this._autosaveTimer);
-            this._autosaveTimer = setTimeout(() => {
-                this.saveManager.save(this.state, 'autosave')
-                    .catch(err => console.error('[Engine] Autosave falló:', err));
-            }, 2500);
-        }
-
-        // Auto-avance si está activo
-        if (this.autoMode) {
-            clearTimeout(this._autoTimer);
-            this._autoTimer = setTimeout(() => {
-                if (this.autoMode && !this.isBlocked) this.next();
-            }, this.autoDelay);
-
-        // Skip mode: continuar si aún hay contenido ya visto por delante
-        } else if (this.skipMode) {
-            if (this.currentIndex <= this.highWaterMark) {
-                clearTimeout(this._autoTimer);
-                this._autoTimer = setTimeout(() => {
-                    if (!this.skipMode || this._nextRunning) return;
-                    // Llamar _nextInternal directamente — sabemos que isBlocked = false
-                    // y evitamos que los guards de next() descarten el avance.
-                    this._nextRunning = true;
-                    this._nextInternal().finally(() => { this._nextRunning = false; });
-                }, 30);
-            } else {
-                // Llegamos al límite del contenido visto — parar automáticamente
-                this._stopSkip();
-            }
-        }
+    /**
+     * @param {string} relativePath
+     * @returns {string}
+     */
+    #buildAssetUrl(relativePath) {
+        return `${DEPLOYMENT_BASE_URL}${relativePath.replace(/^\//, '')}`;
     }
 
-    /** '2s' → 2000 | '500ms' → 500 | '1.5s' → 1500 */
-    _parseDuration(str) {
-        if (str.endsWith('ms')) return parseInt(str);
-        return Math.round(parseFloat(str) * 1000);
+    /** @param {BacklogEntry} entry */
+    #pushToBacklog(entry) {
+        this.backlog.push(entry);
+        if (this.backlog.length > BACKLOG_MAX_ENTRIES) this.backlog.shift();
     }
 
-    _getActorSlot(actorId) {
-        return Object.keys(this.slots).find(k => this.slots[k] === actorId) ?? null;
+    /** @param {boolean} puzzlePassed */
+    #incrementPuzzleCounter(puzzlePassed) {
+        const counterKey   = puzzlePassed ? 'puzzles_solved' : 'puzzles_failed';
+        const currentCount = this.state.getFlag(counterKey, 0) ?? 0;
+        this.state.setFlag(counterKey, String(Number(currentCount) + 1));
     }
 
-    _clearActorFromSlots(actorId) {
-        const old = this._getActorSlot(actorId);
-        if (old) this.slots[old] = null;
+    /**
+     * @param {string} actorId
+     * @returns {SpriteSlot|null}
+     */
+    #findSlotOccupiedByCharacter(actorId) {
+        return Object.keys(this.#occupiedSlots)
+            .find(slot => this.#occupiedSlots[slot] === actorId) ?? null;
     }
+
+    /** @param {string} actorId */
+    #removeCharacterFromOccupiedSlots(actorId) {
+        const previousSlot = this.#findSlotOccupiedByCharacter(actorId);
+        if (previousSlot) this.#occupiedSlots[previousSlot] = null;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // COMPATIBILIDAD — proxies para nombres heredados
+    // Módulos externos aún referencian estos nombres.
+    // Eliminar cuando MenuSystem y canvas.js se actualicen.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** @deprecated usar toggleAutoMode() */
+    toggleAuto()        { return this.toggleAutoMode(); }
+
+    /** @deprecated usar triggerSkipMode() */
+    triggerSkip(onStop) { return this.triggerSkipMode(onStop); }
+
+    /** @deprecated usar stopAllReadingModes() */
+    stopModes()         { return this.stopAllReadingModes(); }
 }

--- a/src/core/SaveManager.js
+++ b/src/core/SaveManager.js
@@ -1,38 +1,68 @@
 // src/core/SaveManager.js
-//
-// RESPONSABILIDADES:
-//   1. Guardar y cargar partidas en Dexie (persistencia local)
-//   2. Exportar partidas como archivo .json descargable
-//   3. Importar partidas desde un archivo .json
-//
-// SLOTS PREDEFINIDOS:
-//   'autosave'  → guardado automático tras cada diálogo
-//   'slot_1'    → slot manual del jugador (expandible a slot_2, slot_3...)
-//
-// SaveManager NO conoce al Engine ni al Renderer.
-// Solo maneja datos planos (GameState.toJSON()).
 
 import { GameState } from './State.js';
 
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {'autosave' | 'slot_1' | 'slot_2' | 'slot_3'} SaveSlotId
+ */
+
+/**
+ * @typedef {Object} SlotSummary
+ * @property {SaveSlotId} slotId
+ * @property {number}     savedAt
+ * @property {string}     currentFile
+ * @property {number}     currentIndex
+ */
+
+// ─── SaveManager ─────────────────────────────────────────────────────────────
+
+/**
+ * Gestiona la persistencia de partidas en Dexie (IndexedDB).
+ *
+ * Responsabilidades:
+ * - Guardar y cargar `GameState` en slots predefinidos
+ * - Exportar e importar partidas como archivos `.json`
+ * - Eliminar slots individuales
+ *
+ * No conoce al Engine ni al Renderer — opera exclusivamente con
+ * objetos planos (`GameState.toJSON()` / `GameState.fromJSON()`).
+ *
+ * Slots disponibles:
+ * - `autosave` — guardado automático tras cada diálogo
+ * - `slot_1`, `slot_2`, `slot_3` — slots manuales del jugador
+ *
+ * @example
+ * const saveManager = new SaveManager(db);
+ * await saveManager.save(engine.state, 'slot_1');
+ * const restoredState = await saveManager.load('slot_1');
+ */
 export class SaveManager {
+
+    /** @type {import('dexie').Dexie} */
+    db;
+
+    /** @param {import('dexie').Dexie} db */
     constructor(db) {
         this.db = db;
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // DEXIE — Persistencia local
-    // ─────────────────────────────────────────────────────────────────────────
+    // ── Persistencia en Dexie ──────────────────────────────────────────────
 
     /**
-     * Guarda el estado actual en un slot.
-     * @param {GameState} state  - Estado a guardar
-     * @param {string}    slotId - Identificador del slot (ej: 'autosave', 'slot_1')
+     * Guarda el estado actual en el slot indicado.
+     * Sobrescribe si el slot ya tenía datos.
+     *
+     * @param {GameState}   state
+     * @param {SaveSlotId}  slotId
+     * @returns {Promise<object>} — el snapshot guardado
      */
     async save(state, slotId = 'autosave') {
         const snapshot = {
             slotId,
             ...state.toJSON(),
-            savedAt: Date.now(), // DESPUÉS del spread — gana sobre state.savedAt
+            savedAt: Date.now(), // sobreescribe state.savedAt con el timestamp real
         };
 
         await this.db.saves.put(snapshot);
@@ -41,24 +71,27 @@ export class SaveManager {
     }
 
     /**
-     * Carga un slot y devuelve una instancia de GameState.
-     * @param   {string}          slotId
-     * @returns {GameState|null}
+     * Carga un slot y devuelve una instancia de `GameState`.
+     * Devuelve `null` si el slot está vacío.
+     *
+     * @param   {SaveSlotId}      slotId
+     * @returns {Promise<GameState|null>}
      */
     async load(slotId = 'autosave') {
-        const data = await this.db.saves.get(slotId);
-        if (!data) {
+        const snapshot = await this.db.saves.get(slotId);
+
+        if (!snapshot) {
             console.warn(`[SaveManager] Slot "${slotId}" vacío.`);
             return null;
         }
 
         console.log(`[SaveManager] Cargado desde "${slotId}".`);
-        return GameState.fromJSON(data);
+        return GameState.fromJSON(snapshot);
     }
 
     /**
-     * Devuelve la lista de todos los slots guardados, ordenados por fecha.
-     * @returns {Array<{slotId, savedAt, currentFile, currentIndex}>}
+     * Devuelve un resumen de todos los slots guardados, ordenados por fecha desc.
+     * @returns {Promise<SlotSummary[]>}
      */
     async listSlots() {
         return await this.db.saves
@@ -69,69 +102,68 @@ export class SaveManager {
 
     /**
      * Elimina un slot específico.
-     * @param {string} slotId
+     * @param {SaveSlotId} slotId
      */
     async deleteSlot(slotId) {
         await this.db.saves.delete(slotId);
         console.log(`[SaveManager] Slot "${slotId}" eliminado.`);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // JSON — Exportar e importar partidas
-    // ─────────────────────────────────────────────────────────────────────────
+    // ── Export / Import JSON ───────────────────────────────────────────────
 
     /**
-     * Descarga el estado actual como un archivo .json.
-     * El nombre del archivo incluye la fecha para fácil identificación.
+     * Descarga el estado actual como archivo `.json`.
+     * El nombre incluye la fecha para identificación fácil.
      * @param {GameState} state
      */
     exportToFile(state) {
-        const data     = state.toJSON();
-        const json     = JSON.stringify(data, null, 2);
-        const blob     = new Blob([json], { type: 'application/json' });
-        const url      = URL.createObjectURL(blob);
+        const snapshot      = state.toJSON();
+        const jsonContent   = JSON.stringify(snapshot, null, 2);
+        const exportDate    = new Date().toISOString().slice(0, 10);
+        const downloadName  = `dramaturge_save_${exportDate}.json`;
 
-        const date     = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-        const filename = `dramaturge_save_${date}.json`;
+        const blob         = new Blob([jsonContent], { type: 'application/json' });
+        const downloadUrl  = URL.createObjectURL(blob);
+        const anchorElement = document.createElement('a');
 
-        const a   = document.createElement('a');
-        a.href    = url;
-        a.download = filename;
-        a.click();
+        anchorElement.href     = downloadUrl;
+        anchorElement.download = downloadName;
+        anchorElement.click();
 
-        // Liberar la URL del objeto inmediatamente
-        URL.revokeObjectURL(url);
-        console.log(`[SaveManager] Exportado como "${filename}".`);
+        URL.revokeObjectURL(downloadUrl);
+        console.log(`[SaveManager] Exportado como "${downloadName}".`);
     }
 
     /**
-     * Importa un archivo .json y devuelve una instancia de GameState.
-     * El jugador selecciona el archivo desde su sistema.
+     * Abre un selector de archivo y devuelve el `GameState` importado.
+     * Devuelve `null` si el jugador cancela o el archivo es inválido.
      * @returns {Promise<GameState|null>}
      */
     importFromFile() {
         return new Promise((resolve) => {
-            const input    = document.createElement('input');
-            input.type     = 'file';
-            input.accept   = '.json';
+            const fileInput    = document.createElement('input');
+            fileInput.type     = 'file';
+            fileInput.accept   = '.json';
 
-            input.onchange = async (e) => {
-                const file = e.target.files[0];
-                if (!file) { resolve(null); return; }
+            fileInput.onchange = async (changeEvent) => {
+                const selectedFile = changeEvent.target.files[0];
+                if (!selectedFile) { resolve(null); return; }
 
                 try {
-                    const text  = await file.text();
-                    const data  = JSON.parse(text);
-                    const state = GameState.fromJSON(data);
+                    const fileContent   = await selectedFile.text();
+                    const parsedSnapshot = JSON.parse(fileContent);
+                    const restoredState  = GameState.fromJSON(parsedSnapshot);
+
                     console.log('[SaveManager] Partida importada correctamente.');
-                    resolve(state);
-                } catch (err) {
-                    console.error('[SaveManager] Error al importar:', err.message);
+                    resolve(restoredState);
+
+                } catch (parseError) {
+                    console.error('[SaveManager] Archivo inválido:', parseError.message);
                     resolve(null);
                 }
             };
 
-            input.click();
+            fileInput.click();
         });
     }
 }

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -1,234 +1,223 @@
 // src/core/SceneManager.js
-//
-// RESPONSABILIDADES:
-//   - Cargar archivos .dan desde /public/scripts/ vía fetch
-//   - Parsear el script y entregarlo al Engine
-//   - Ser el handler de goto (inyectado como engine.sceneLoader)
-//
-// CICLO DE VIDA:
-//   1. main.js crea: const sceneManager = new SceneManager(engine, parser)
-//   2. Inyecta:      engine.sceneLoader = (t) => sceneManager.goto(t)
-//   3. Inicia:       await sceneManager.start('cap01/scene_01')
-//
-// CONVENCIÓN DE RUTAS:
-//   target 'cap01/scene_02' → fetch('/scripts/cap01/scene_02.dan')
-//   target 'intro'          → fetch('/scripts/intro.dan')
-//
-// En producción (GitHub Pages) Vite inyecta BASE_URL = '/Dramaturge/' automáticamente.
-// En desarrollo BASE_URL = '/'. No hay que cambiar nada al desplegar.
-//
-// El SceneManager NO conoce al Renderer ni al Audio.
-// Solo coordina Engine + Parser + sistema de archivos.
 
+/**
+ * Gestiona la carga y navegación entre escenas .dan.
+ *
+ * Responsabilidades:
+ * - Descargar archivos .dan desde `/public/scripts/` via fetch
+ * - Parsear el contenido y entregarlo al Engine
+ * - Mantener una caché en memoria de instrucciones ya parseadas
+ * - Ejecutar transiciones de color al navegar entre capítulos
+ *
+ * Convención de rutas:
+ *   `'cap01/scene_02'` → fetch desde `/scripts/cap01/scene_02.dan`
+ *
+ * Integración con el Engine:
+ *   `engine.sceneLoader = (target, fade) => sceneManager.goto(target, fade)`
+ *
+ * @example
+ * const sceneManager = new SceneManager(engine, parser);
+ * engine.sceneLoader = (target, fade) => sceneManager.goto(target, fade);
+ * await sceneManager.start('cap01/scene_01');
+ */
 export class SceneManager {
 
-    /**
-     * @param {Dramaturge} engine   - Instancia del motor
-     * @param {KParser}     parser   - Instancia del parser
-     * @param {string}      basePath - Ruta base de los scripts (default: '/scripts/')
-     */
-    constructor(engine, parser, basePath = `${import.meta.env.BASE_URL}scripts/`) {
-        this.engine   = engine;
-        this.parser   = parser;
-        this.basePath = basePath;
+    /** @type {import('./Engine.js').Dramaturge} */
+    #engine;
 
-        // Caché en memoria: target → instrucciones ya parseadas
-        // Evita re-fetchear y re-parsear una escena visitada más de una vez
-        this._cache = new Map();
+    /** @type {import('./parser/Parser.js').KParser} */
+    #parser;
+
+    /** @type {string} */
+    #scriptsBasePath;
+
+    /**
+     * Caché de instrucciones parseadas por target.
+     * Evita re-fetchear y re-parsear escenas ya visitadas.
+     * @type {Map<string, object[]>}
+     */
+    #parsedInstructionsCache = new Map();
+
+    /**
+     * @param {import('./Engine.js').Dramaturge}      engine
+     * @param {import('./parser/Parser.js').KParser}  parser
+     * @param {string} [scriptsBasePath]
+     */
+    constructor(engine, parser, scriptsBasePath = `${import.meta.env.BASE_URL}scripts/`) {
+        this.#engine          = engine;
+        this.#parser          = parser;
+        this.#scriptsBasePath = scriptsBasePath;
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // API PÚBLICA
-    // ─────────────────────────────────────────────────────────────────────────
+    // ── API pública ────────────────────────────────────────────────────────
 
     /**
-     * Carga la escena de inicio y arranca la ejecución.
-     * Llamar una sola vez desde main.js después de renderer.init().
+     * Carga la escena inicial y arranca la ejecución.
+     * Llamar una sola vez desde `main.js` tras `renderer.init()`.
      * @param {string} startTarget - ej: 'cap01/scene_01'
      */
     async start(startTarget) {
         console.log(`[SceneManager] Iniciando desde "${startTarget}".`);
-        await this._loadAndRun(startTarget);
+        await this.#loadAndRun(startTarget);
     }
 
     /**
      * Navega a otra escena con transición de color opcional.
-     * Inyectado en engine.sceneLoader = (t, f) => sceneManager.goto(t, f)
-     * @param {string}      target    - ej: 'cap01/scene_02'
-     * @param {string|null} fadeColor - 'black' | 'white' | null
+     * Inyectado en `engine.sceneLoader = (t, f) => sceneManager.goto(t, f)`.
+     *
+     * @param {string}                   target
+     * @param {'black' | 'white' | null} [fadeColor]
      */
     async goto(target, fadeColor = null) {
         console.log(`[SceneManager] goto → "${target}"${fadeColor ? ` fade:${fadeColor}` : ''}.`);
 
         if (fadeColor) {
-            // Cargar el script mientras el negro cubre la pantalla,
-            // pero no ejecutar todavía — el fade out dispara el primer next().
-            await this._fadeTransition(fadeColor, async () => {
+            await this.#executeChapterTransition(fadeColor, async () => {
                 await this.loadOnly(target);
             });
         } else {
-            await this._loadAndRun(target);
+            await this.#loadAndRun(target);
         }
     }
 
     /**
-     * Carga e instala el script en el engine SIN ejecutarlo.
-     * Usar para "Continuar" — después llamar engine.next() manualmente.
-     * @param {string} target
-     * @returns {boolean} true si se cargó correctamente
+     * Carga e instala el script en el Engine sin ejecutarlo.
+     * Usar para "Continuar partida" — después llamar `engine.next()` manualmente.
+     *
+     * @param   {string}           target
+     * @returns {Promise<boolean>} — true si se cargó correctamente
      */
     async loadOnly(target) {
-        let instructions = this._cache.get(target);
+        const instructions = await this.#fetchAndParseIfNeeded(target);
+        if (!instructions) return false;
 
-        if (!instructions) {
-            const raw = await this._fetch(target);
-            if (!raw) return false;
-            instructions = this.parser.parse(raw);
-            this._cache.set(target, instructions);
-        }
-
-        this.engine.state.currentFile = `${target}.dan`;
-        await this.engine.loadScript(instructions);
+        this.#engine.state.currentFile = `${target}.dan`;
+        await this.#engine.loadScript(instructions);
         return true;
     }
 
     /**
      * Precarga una escena en caché sin ejecutarla.
-     * Útil para precargar la siguiente escena mientras el jugador lee la actual.
+     * Útil para anticipar la escena siguiente mientras el jugador lee la actual.
      * @param {string} target
      */
     async prefetch(target) {
-        if (this._cache.has(target)) return;
-        const raw = await this._fetch(target);
-        if (raw) {
-            this._cache.set(target, this.parser.parse(raw));
-            console.log(`[SceneManager] Precargado "${target}".`);
-        }
+        if (this.#parsedInstructionsCache.has(target)) return;
+        const instructions = await this.#fetchAndParseIfNeeded(target);
+        if (instructions) console.log(`[SceneManager] Precargado "${target}".`);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // HELPERS PRIVADOS
-    // ─────────────────────────────────────────────────────────────────────────
+    // ── Carga y ejecución ──────────────────────────────────────────────────
 
-    async _loadAndRun(target) {
-        // 1. Obtener instrucciones (caché o fetch)
-        let instructions = this._cache.get(target);
+    /** @param {string} target */
+    async #loadAndRun(target) {
+        const instructions = await this.#fetchAndParseIfNeeded(target);
+        if (!instructions) return;
 
-        if (!instructions) {
-            const raw = await this._fetch(target);
-            if (!raw) return; // error ya logueado en _fetch
-
-            instructions = this.parser.parse(raw);
-            this._cache.set(target, instructions);
-        }
-
-        // 2. Actualizar state con la escena activa
-        this.engine.state.currentFile = `${target}.dan`;
-
-        // 3. Cargar en el engine y arrancar
-        await this.engine.loadScript(instructions);
-        await this.engine.next(); // ejecutar la primera instrucción automáticamente
+        this.#engine.state.currentFile = `${target}.dan`;
+        await this.#engine.loadScript(instructions);
+        await this.#engine.next();
     }
 
     /**
-     * Descarga un archivo .dan del servidor.
-     * @param   {string}      target
-     * @returns {string|null} Contenido del archivo, o null si no se encontró
+     * Devuelve instrucciones desde caché o las descarga y parsea.
+     * @param   {string} target
+     * @returns {Promise<object[]|null>}
      */
-    async _fetch(target) {
-        const url = `${this.basePath}${target}.dan`;
+    async #fetchAndParseIfNeeded(target) {
+        const cachedResult = this.#parsedInstructionsCache.get(target);
+        if (cachedResult) return cachedResult;
+
+        const rawScriptContent = await this.#fetchScriptFile(target);
+        if (!rawScriptContent) return null;
+
+        const parsedInstructions = this.#parser.parse(rawScriptContent);
+        this.#parsedInstructionsCache.set(target, parsedInstructions);
+        return parsedInstructions;
+    }
+
+    /**
+     * Descarga el archivo .dan del servidor.
+     * @param   {string}        target
+     * @returns {Promise<string|null>}
+     */
+    async #fetchScriptFile(target) {
+        const scriptUrl = `${this.#scriptsBasePath}${target}.dan`;
 
         try {
-            const response = await fetch(url);
+            const response = await fetch(scriptUrl);
 
             if (!response.ok) {
-                // 404 es un error del escritor (ruta incorrecta), no del engine
                 if (response.status === 404) {
-                    console.error(`[SceneManager] Script no encontrado: "${url}"`);
-                    console.error(`[SceneManager] Verifica que el archivo exista en public/scripts/${target}.dan`);
+                    console.error(`[SceneManager] Script no encontrado: "${scriptUrl}"`);
                 } else {
-                    console.error(`[SceneManager] Error ${response.status} al cargar "${url}"`);
+                    console.error(`[SceneManager] Error ${response.status} al cargar "${scriptUrl}"`);
                 }
                 return null;
             }
 
             return await response.text();
 
-        } catch (err) {
-            // Error de red (sin conexión, CORS, etc.)
-            console.error(`[SceneManager] Error de red al cargar "${url}":`, err.message);
+        } catch (networkError) {
+            console.error(`[SceneManager] Error de red: "${scriptUrl}"`, networkError.message);
             return null;
         }
     }
 
+    // ── Transición de capítulo ─────────────────────────────────────────────
+
     /**
-     * Transición de fundido estructural entre capítulos.
+     * Transición estructural entre capítulos.
      *
-     * Tiempos deliberadamente lentos — esta no es una transición expresiva
-     * sino una señal al jugador de que algo importante está cambiando.
-     * El escritor no controla la duración: es una decisión del motor.
+     * Tiempos deliberadamente lentos — señal al jugador de que algo importante
+     * está cambiando. La duración es decisión del motor, no del escritor.
      *
      * Secuencia:
-     *   1. Fade IN  → 800ms  (pantalla se oscurece)
-     *   2. Hold     → 300ms  (negro total — aquí se limpia la escena)
-     *   3. La escena nueva carga mientras el negro está activo
-     *   4. Fade OUT → 800ms  (pantalla aparece con el nuevo estado)
+     *   1. Fade IN  → 800ms (pantalla se oscurece)
+     *   2. Hold     → 300ms (negro total — se limpia y carga la escena nueva)
+     *   3. Fade OUT → 800ms (pantalla revela el nuevo estado)
      *
      * El input queda bloqueado durante toda la transición.
-     * El skip mode no puede saltarse este momento.
      *
-     * @param {'black'|'white'} color
+     * @param {'black' | 'white'}   color
+     * @param {() => Promise<void>} onSceneReady — ejecutado mientras la pantalla está opaca
      * @returns {Promise<void>}
      */
-    _fadeTransition(color, onReady = null) {
+    #executeChapterTransition(color, onSceneReady) {
         return new Promise((resolve) => {
-            const el = document.getElementById('scene-transition');
-            if (!el) { resolve(); return; }
+            const transitionOverlay = document.getElementById('scene-transition');
+            if (!transitionOverlay) { resolve(); return; }
 
             const FADE_IN_MS  = 800;
             const HOLD_MS     = 300;
             const FADE_OUT_MS = 800;
 
-            // Bloquear input durante toda la transición
-            this.engine.isBlocked = true;
+            this.#engine.isBlocked                = true;
+            transitionOverlay.style.background    = color === 'white' ? '#ffffff' : '#000000';
+            transitionOverlay.style.transition    = `opacity ${FADE_IN_MS}ms ease`;
+            transitionOverlay.style.pointerEvents = 'all';
+            transitionOverlay.style.opacity       = '0';
 
-            el.style.background    = color === 'white' ? '#ffffff' : '#000000';
-            el.style.transition    = `opacity ${FADE_IN_MS}ms ease`;
-            el.style.pointerEvents = 'all';
-            el.style.opacity       = '0';
+            void transitionOverlay.offsetHeight; // fuerza reflow
 
-            // Forzar reflow para que la transición CSS arranque desde 0
-            void el.offsetHeight;
+            transitionOverlay.style.opacity = '1';
 
-            // ── Fase 1: Fade IN ───────────────────────────────────────────────
-            el.style.opacity = '1';
+            setTimeout(async () => {
+                // Pantalla opaca — limpiar escena anterior y cargar la nueva
+                this.#engine.renderer.clearScene?.();
 
-            setTimeout(() => {
+                await onSceneReady();
+                resolve();
 
-                // ── Fase 2: Hold — limpiar escena mientras el negro cubre todo ──
-                this.engine.renderer.clearScene?.();
-                this.engine.activePawns.clear();
-                this.engine.slots = { left: null, center: null, right: null };
-
-                // La escena nueva se carga aquí (el caller hace _loadAndRun tras resolve)
-                setTimeout(async () => {
-                    // Cargar el script mientras el negro está activo
-                    await onReady?.();
-
-                    resolve();
-
-                    // ── Fase 3: Fade OUT — tras cargar la escena nueva ────────
-                    el.style.transition = `opacity ${FADE_OUT_MS}ms ease`;
-                    void el.offsetHeight;
-                    el.style.opacity = '0';
+                setTimeout(() => {
+                    transitionOverlay.style.transition = `opacity ${FADE_OUT_MS}ms ease`;
+                    void transitionOverlay.offsetHeight;
+                    transitionOverlay.style.opacity = '0';
 
                     setTimeout(() => {
-                        el.style.pointerEvents = 'none';
-                        // Desbloquear input y arrancar la primera instrucción
-                        // automáticamente — el jugador no necesita hacer clic
-                        // para salir del negro.
-                        this.engine.isBlocked = false;
-                        this.engine.next();
+                        transitionOverlay.style.pointerEvents = 'none';
+                        this.#engine.isBlocked = false;
+                        this.#engine.next();
                     }, FADE_OUT_MS);
 
                 }, HOLD_MS);

--- a/src/core/State.js
+++ b/src/core/State.js
@@ -1,103 +1,210 @@
 // src/core/State.js
-//
-// GameState es el ÚNICO objeto que se serializa para save/load.
-// El Engine lo mantiene sincronizado; SaveManager lo persiste.
-//
-//   Todos los campos de esta clase deben ser primitivos, arrays, u objetos planos.
-//   No guardar instancias de clases, Promises, ni referencias al DOM.
 
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} AudioSettings
+ * @property {number} bgmVolume   - 0.0 a 1.0
+ * @property {number} sfxVolume   - 0.0 a 1.0
+ * @property {number} voiceVolume - 0.0 a 1.0
+ */
+
+/**
+ * @typedef {Object} ActiveBgmState
+ * @property {string} track - Nombre del archivo sin extensión
+ * @property {number} vol   - Volumen al momento de guardar (0.0 a 1.0)
+ */
+
+/**
+ * @typedef {Object} SpriteSlotState
+ * @property {string} actorId - ID del personaje ocupando el slot
+ * @property {string} path    - Ruta completa del sprite activo
+ */
+
+/**
+ * @typedef {Object} VisualState
+ * @property {string|null}                       bg      - Nombre del fondo activo o null
+ * @property {Record<string, SpriteSlotState>}   sprites - Estado de cada slot de sprite
+ * @property {'dialogue' | 'narrate' | null}     mode    - Modo de textbox activo
+ * @property {ActiveBgmState|null}               bgm     - BGM activo o null
+ */
+
+/**
+ * @typedef {Object} GameStateSnapshot
+ * @property {string}                    currentFile
+ * @property {number}                    currentIndex
+ * @property {number}                    highWaterMark
+ * @property {Record<string, *>}         flags
+ * @property {string[]}                  inventory
+ * @property {AudioSettings}             audioSettings
+ * @property {VisualState}               visualState
+ * @property {number|null}               savedAt
+ * @property {number}                    playTime
+ */
+
+// ─── GameState ────────────────────────────────────────────────────────────────
+
+/**
+ * Estado serializable completo de una partida.
+ *
+ * Es el único objeto que viaja entre el Engine y el SaveManager.
+ * Todos sus campos deben ser primitivos, arrays u objetos planos —
+ * sin instancias de clases, Promises ni referencias al DOM.
+ *
+ * El Engine lo mantiene sincronizado; SaveManager lo persiste en Dexie.
+ *
+ * @example
+ * const state = new GameState();
+ * state.setFlag('cap01_completo', 'true');
+ * state.addItem('llave_maestra');
+ * const snapshot = state.toJSON(); // listo para Dexie
+ */
 export class GameState {
-    constructor(data = {}) {
-        // ── Progreso narrativo ────────────────────────────────────────────
-        // Nombre del archivo .dan activo (para cargar el script correcto al reanudar)
-        this.currentFile  = data.currentFile  ?? 'inicio.dan';
 
-        // Índice de la próxima instrucción a ejecutar.
-        // Se sincroniza con engine.currentIndex antes de cada save.
-        this.currentIndex = data.currentIndex ?? 0;
+    // ── Progreso narrativo ─────────────────────────────────────────────────
 
-        // ── Flags de historia ─────────────────────────────────────────────
-        // Activados con: set flag.key = value
-        // Ejemplo: { 'puzzle_P01_solved': true, 'conociste_a_miki': true }
-        this.flags        = data.flags        ?? {};
+    /** @type {string} — archivo .dan activo, necesario para reanudar la partida */
+    currentFile;
 
-        // ── Inventario ────────────────────────────────────────────────────
-        // Array de strings (item keys). Sin duplicados.
-        // Modificado con: set inventory.add key  /  set inventory.remove key
-        this.inventory    = data.inventory    ?? [];
+    /** @type {number} — índice de la próxima instrucción a ejecutar */
+    currentIndex;
 
-        // ── Configuración de audio ────────────────────────────────────────
-        // Persiste entre sesiones. Modificado desde el panel de ajustes.
+    /**
+     * Índice más alto completado por el jugador en esta partida.
+     * El modo skip solo avanza hasta este punto — nunca más allá.
+     * @type {number}
+     */
+    highWaterMark;
+
+    // ── Historia y objetos ─────────────────────────────────────────────────
+
+    /**
+     * Flags de historia activados con `set flag.key = value`.
+     * @type {Record<string, boolean|number|string>}
+     */
+    flags;
+
+    /**
+     * Inventario del jugador. Array sin duplicados.
+     * Modificado con `set inventory.add` y `set inventory.remove`.
+     * @type {string[]}
+     */
+    inventory;
+
+    // ── Preferencias persistentes ──────────────────────────────────────────
+
+    /** @type {AudioSettings} */
+    audioSettings;
+
+    // ── Estado visual y de audio para restaurar al cargar ─────────────────
+
+    /** @type {VisualState} */
+    visualState;
+
+    // ── Metadata del save ──────────────────────────────────────────────────
+
+    /** @type {number|null} — timestamp del último guardado */
+    savedAt;
+
+    /** @type {number} — segundos acumulados de juego */
+    playTime;
+
+    /** @param {Partial<GameStateSnapshot>} [snapshot] */
+    constructor(snapshot = {}) {
+        this.currentFile   = snapshot.currentFile   ?? 'inicio.dan';
+        this.currentIndex  = snapshot.currentIndex  ?? 0;
+        this.highWaterMark = snapshot.highWaterMark ?? 0;
+        this.flags         = snapshot.flags         ?? {};
+        this.inventory     = snapshot.inventory     ?? [];
+        this.savedAt       = snapshot.savedAt       ?? null;
+        this.playTime      = snapshot.playTime      ?? 0;
+
         this.audioSettings = {
-            bgmVolume:   data.audioSettings?.bgmVolume   ?? 0.5,
-            sfxVolume:   data.audioSettings?.sfxVolume   ?? 0.8,
-            voiceVolume: data.audioSettings?.voiceVolume ?? 1.0,
+            bgmVolume:   snapshot.audioSettings?.bgmVolume   ?? 0.5,
+            sfxVolume:   snapshot.audioSettings?.sfxVolume   ?? 0.8,
+            voiceVolume: snapshot.audioSettings?.voiceVolume ?? 1.0,
         };
 
-        // ── Estado visual activo ─────────────────────────────────────────────
-        // Guardado automáticamente por el Engine en cada BG_CHANGE / SPRITE_SHOW/HIDE.
-        // Permite restaurar la pantalla al cargar sin tener que re-ejecutar el script.
-        //
-        //   bg:      ruta del fondo activo  (string | null)
-        //   sprites: { slot → { actorId, path } }  — slots 'left','center','right'
-        //   mode:    'dialogue' | 'narrate' | null  — modo de textbox activo
-        this.visualState = data.visualState ?? { bg: null, sprites: {}, mode: null };
-
-        // ── Progreso de lectura — para el modo skip ─────────────────────
-        // Índice más alto completado por el jugador.
-        // Skip solo avanza automáticamente hasta este punto — nunca más allá.
-        this.highWaterMark = data.highWaterMark ?? 0;
-
-        // ── Metadata del save ─────────────────────────────────────────────────
-        this.savedAt  = data.savedAt  ?? null; // timestamp del último guardado
-        this.playTime = data.playTime ?? 0;    // segundos acumulados de juego
+        this.visualState = {
+            bg:      snapshot.visualState?.bg      ?? null,
+            sprites: snapshot.visualState?.sprites ?? {},
+            mode:    snapshot.visualState?.mode    ?? null,
+            bgm:     snapshot.visualState?.bgm     ?? null,
+        };
     }
 
-    // ─── Operaciones de inventario ────────────────────────────────────────────
+    // ── Inventario ─────────────────────────────────────────────────────────
 
+    /**
+     * Añade un ítem al inventario si no existe ya.
+     * @param {string} itemKey
+     */
     addItem(itemKey) {
         if (!this.inventory.includes(itemKey)) {
             this.inventory.push(itemKey);
         }
     }
 
+    /**
+     * Elimina un ítem del inventario.
+     * @param {string} itemKey
+     */
     removeItem(itemKey) {
-        this.inventory = this.inventory.filter(k => k !== itemKey);
+        this.inventory = this.inventory.filter(key => key !== itemKey);
     }
 
+    /**
+     * @param {string} itemKey
+     * @returns {boolean}
+     */
     hasItem(itemKey) {
         return this.inventory.includes(itemKey);
     }
 
-    // ─── Operaciones de flags ─────────────────────────────────────────────────
+    // ── Flags ──────────────────────────────────────────────────────────────
 
-    setFlag(key, value) {
-        // Parsear el valor si viene como string desde el Parser
-        if (value === 'true')  this.flags[key] = true;
-        else if (value === 'false') this.flags[key] = false;
-        else if (!isNaN(value))     this.flags[key] = Number(value);
-        else                        this.flags[key] = value; // string literal
+    /**
+     * Establece un flag parseando el valor a su tipo nativo.
+     * `'true'`/`'false'` → boolean, numéricos → number, resto → string.
+     *
+     * @param {string} key
+     * @param {string} rawValue — valor como string desde el Parser
+     */
+    setFlag(key, rawValue) {
+        if (rawValue === 'true')       this.flags[key] = true;
+        else if (rawValue === 'false') this.flags[key] = false;
+        else if (!isNaN(rawValue))     this.flags[key] = Number(rawValue);
+        else                           this.flags[key] = rawValue;
     }
 
-    getFlag(key, defaultValue = null) {
-        return this.flags[key] ?? defaultValue;
+    /**
+     * @param {string} key
+     * @param {*}      [fallback=null]
+     * @returns {boolean|number|string|null}
+     */
+    getFlag(key, fallback = null) {
+        return this.flags[key] ?? fallback;
     }
 
-    // ─── Serialización ────────────────────────────────────────────────────────
+    // ── Serialización ──────────────────────────────────────────────────────
 
-    /** Devuelve un objeto plano listo para guardar en Dexie o exportar a JSON. */
+    /**
+     * Devuelve un snapshot plano listo para Dexie o exportar a JSON.
+     * @returns {GameStateSnapshot}
+     */
     toJSON() {
         return {
             currentFile:   this.currentFile,
             currentIndex:  this.currentIndex,
+            highWaterMark: this.highWaterMark,
             flags:         { ...this.flags },
             inventory:     [...this.inventory],
             audioSettings: { ...this.audioSettings },
-            highWaterMark: this.highWaterMark,
-            visualState:   {
+            visualState: {
                 bg:      this.visualState.bg,
                 sprites: { ...this.visualState.sprites },
                 mode:    this.visualState.mode,
+                bgm:     this.visualState.bgm ? { ...this.visualState.bgm } : null,
             },
             savedAt:  this.savedAt,
             playTime: this.playTime,
@@ -105,25 +212,29 @@ export class GameState {
     }
 
     /**
-     * Resetea el estado a una partida nueva, conservando las preferencias de audio.
-     * Llamado por Engine.reset() al iniciar Nueva Partida.
+     * Resetea todos los campos narrativos para una partida nueva.
+     * Preserva `audioSettings` — son preferencias del jugador, no del juego.
      */
     reset() {
-        const audio = { ...this.audioSettings }; // conservar preferencias
-        // Re-inicializar todos los campos narrativos
+        const preservedAudioSettings = { ...this.audioSettings };
+
         this.currentFile   = 'inicio.dan';
         this.currentIndex  = 0;
+        this.highWaterMark = 0;
         this.flags         = {};
         this.inventory     = [];
-        this.visualState   = { bg: null, sprites: {}, mode: null };
-        this.highWaterMark = 0;
+        this.visualState   = { bg: null, sprites: {}, mode: null, bgm: null };
         this.savedAt       = null;
         this.playTime      = 0;
-        this.audioSettings = audio; // restaurar preferencias
+        this.audioSettings = preservedAudioSettings;
     }
 
-    /** Crea una instancia de GameState desde un objeto plano (Dexie o JSON importado). */
-    static fromJSON(data) {
-        return new GameState(data);
+    /**
+     * Crea una instancia desde un snapshot plano (Dexie o JSON importado).
+     * @param {GameStateSnapshot} snapshot
+     * @returns {GameState}
+     */
+    static fromJSON(snapshot) {
+        return new GameState(snapshot);
     }
 }

--- a/src/core/database/db.js
+++ b/src/core/database/db.js
@@ -1,24 +1,27 @@
 // src/core/database/db.js
+
 import Dexie from 'dexie';
 
-export const db = new Dexie('DramaturgeDB');
+// ─── DramaturgeDB ─────────────────────────────────────────────────────────────
 
-// ─── CONTRATO DE DATOS ────────────────────────────────────────────────────────
-//
-// REGLAS:
-//   - Solo declarar campos como índice si se van a usar en .where() o .get().
-//   - El resto de los campos se almacenan automáticamente sin declararlos aquí.
-//   - Para agregar tablas nuevas: incrementar la versión y redeclarar TODAS las tablas.
-//     Dexie maneja la migración automáticamente si no se eliminan tablas existentes.
-//
-// TABLA: characters
-//   PK: id (string manual, ej: 'valeria') — permite db.characters.get('valeria') en O(1)
-//
-// TABLA: saves
-//   PK: slotId (string, ej: 'slot_1', 'autosave')
-//   savedAt: timestamp numérico — indexado para ordenar por fecha
-//
-// TABLA: puzzles / inventory — reservadas para uso futuro
+/**
+ * Base de datos local del motor. Usa Dexie v4 sobre IndexedDB.
+ *
+ * Tablas:
+ * - `characters` — actores y sus poses. Gestionado desde `/dev/characters.html`.
+ * - `puzzles`    — definición de puzzles del juego.
+ * - `saves`      — partidas guardadas (autosave + 3 slots manuales).
+ * - `gallery`    — CGs desbloqueados. Meta-progreso: sobrevive a nuevas partidas.
+ *
+ * Regla de migración:
+ *   Nunca modificar una versión ya publicada.
+ *   Siempre añadir `version(N+1)` con el schema completo.
+ *   Dexie aplica la migración automáticamente en el primer arranque.
+ *
+ * Solo se declaran como índices los campos usados en `.where()` o `.get()`.
+ * El resto de los campos se almacenan automáticamente sin declararlos.
+ */
+export const db = new Dexie('DramaturgeDB');
 
 db.version(1).stores({
     characters: 'id, name',
@@ -26,17 +29,13 @@ db.version(1).stores({
     inventory:  'itemKey',
 });
 
-// Versión 2: agrega la tabla de partidas guardadas.
-// Dexie aplica la migración automáticamente en el primer arranque tras la actualización.
 db.version(2).stores({
     characters: 'id, name',
     puzzles:    'puzzleId, type',
     inventory:  'itemKey',
     saves:      'slotId, savedAt',
 });
-// Versión 3: agrega la galería de CGs.
-// id:         identificador del CG (ej: 'cg_01') — clave primaria
-// unlockedAt: timestamp — indexado para ordenar por orden de desbloqueo
+
 db.version(3).stores({
     characters: 'id, name',
     puzzles:    'puzzleId, type',

--- a/src/core/models/Character.js
+++ b/src/core/models/Character.js
@@ -1,26 +1,83 @@
-// Character.js
+// src/core/models/Character.js
+
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} PoseDefinition
+ * @property {string|null} alias - Nombre usado en el script .dan (ej: 'neutral', 'triste')
+ * @property {string|null} file  - Nombre del archivo relativo a basePath (sin extensión)
+ */
+
+/**
+ * @typedef {Object} CharacterData
+ * @property {string}            id
+ * @property {string}            name
+ * @property {string}            basePath    - Ruta base de sprites, ej: '/assets/sprites/v/'
+ * @property {string}            voicePrefix - Prefijo de archivos de voz, ej: 'VAL_'
+ * @property {PoseDefinition[]}  poses
+ */
+
+// ─── Character ────────────────────────────────────────────────────────────────
+
+/**
+ * Modelo de un personaje cargado en memoria desde la DB.
+ *
+ * Encapsula la resolución de sprites por alias de pose.
+ * Se instancia desde `CharacterData` (objeto plano de Dexie) —
+ * nunca se serializa de vuelta a la DB.
+ *
+ * @example
+ * const character = new Character(characterData);
+ * const spritePath = character.getSprite('neutral'); // '/assets/sprites/v/v_idle'
+ */
 export class Character {
-    constructor(data) {
-        this.id = data.id;
-        this.name = data.name;
-        this.basePath = data.basePath; // ej: 'assets/sprites/valeria/'
-        this.voicePrefix = data.voicePrefix; // ej: 'VAL_'
-        
-        // Estructura de 8 slots fijos para poses (escalable)
-        this.poses = Array(8).fill(null).map((_, i) => ({
-            file: data.poses?.[i]?.file || null,
-            alias: data.poses?.[i]?.alias || null
+
+    /** @type {string} */
+    id;
+
+    /** @type {string} — nombre visible en los diálogos */
+    name;
+
+    /** @type {string} — ruta base de la carpeta de sprites */
+    basePath;
+
+    /** @type {string} — prefijo de archivos de voz, ej: 'VAL_' → 'VAL_001.mp3' */
+    voicePrefix;
+
+    /** @type {PoseDefinition[]} — poses disponibles para este personaje */
+    #poses;
+
+    /** @param {CharacterData} characterData */
+    constructor(characterData) {
+        this.id          = characterData.id;
+        this.name        = characterData.name;
+        this.basePath    = characterData.basePath;
+        this.voicePrefix = characterData.voicePrefix;
+
+        // Normalizar a 8 slots — estructura fija del panel de personajes
+        this.#poses = Array(8).fill(null).map((_, index) => ({
+            alias: characterData.poses?.[index]?.alias ?? null,
+            file:  characterData.poses?.[index]?.file  ?? null,
         }));
     }
 
+    // ── API pública ────────────────────────────────────────────────────────
+
     /**
-     * Obtiene la ruta del sprite por su alias usando búsqueda optimizada.
+     * Devuelve la ruta del sprite para el alias de pose dado.
+     * La ruta no incluye extensión — el Renderer prueba webp → png → jpg.
+     *
+     * @param   {string} poseAlias - ej: 'neutral', 'triste', 'sorpresa'
+     * @returns {string}           - ej: '/assets/sprites/v/v_idle'
+     * @throws  {Error}            - Si el alias no existe para este personaje
      */
-    getSprite(alias) {
-        const pose = this.poses.find(p => p.alias === alias);
-        if (!pose || !pose.file) {
-            throw new Error(`[EMS Error] Alias "${alias}" no definido para el actor ${this.id}`);
+    getSprite(poseAlias) {
+        const matchingPose = this.#poses.find(pose => pose.alias === poseAlias);
+
+        if (!matchingPose?.file) {
+            throw new Error(`[Character] Pose "${poseAlias}" no definida para "${this.id}".`);
         }
-        return `${this.basePath}${pose.file}`;
+
+        return `${this.basePath}${matchingPose.file}`;
     }
 }

--- a/src/core/parser/Grammar.js
+++ b/src/core/parser/Grammar.js
@@ -1,116 +1,101 @@
 // src/core/parser/Grammar.js
-//
-// SINTAXIS COMPLETA DEL LENGUAJE KOEDAN (.dan)
-// ─────────────────────────────────────────────────────────────────────────────
-//
-// PARA AÑADIR UNA REGLA:
-//   1. Definir el regex aquí con named groups (?<nombre>)
-//   2. Añadir entrada en PARSE_RULES (Parser.js)
-//   3. Añadir case en Engine.js execute()
-//
-// REFERENCIA RÁPIDA:
-//
-//   pawn valeria, miki
-//   show valeria:neutral at left fade
-//   hide valeria fade
-//   valeria:triste "Texto del diálogo." [001]
-//   narrate "Texto de narración sin personaje."
-//   bg.set forest fade:2s
-//   audio.bgm play[track_01] vol:0.5
-//   audio.se  play[explosion] vol:0.8
-//   wait 2s
-//   wait 500ms
-//   puzzle P01 pass:"¡Lo lograste!" fail:"Casi. Sigamos."
-//   goto cap01/scene_02
-//   set flag.puzzle_solved = true
-//   set inventory.add llave_maestra
-//   set inventory.remove llave_maestra
 
+/**
+ * Expresiones regulares del lenguaje Koedan (.dan).
+ *
+ * Cada entrada usa named groups (`?<nombre>`) para que el Parser
+ * pueda extraer los valores por nombre sin depender de índices posicionales.
+ *
+ * Para añadir una instrucción nueva al lenguaje:
+ *   1. Definir el regex aquí con named groups
+ *   2. Añadir la entrada en `PARSE_RULES` (Parser.js)
+ *   3. Añadir el `case` correspondiente en `Engine.js`
+ *
+ * @type {Record<string, RegExp>}
+ */
 export const KDN_GRAMMAR = {
 
     // ── Personajes ────────────────────────────────────────────────────────────
-
-    // pawn valeria, miki
+    // pawn valeria
+    // pawn valeria, miki, aldric
     PAWN_INSTANTIATE: /^pawn\s+(?<names>.+)/,
 
-    // show actor:pose at slot [effect]
+    // show valeria:neutral at center
+    // show valeria:neutral at left fade
+    // show miki:neutral at right slide
     SHOW: /^show\s+(?<actor>\w+):(?<pose>\w+)\s+at\s+(?<slot>\w+)(?:\s+(?<effect>\w+))?/,
 
-    // hide actor [effect]
+    // hide valeria
+    // hide valeria fade
     HIDE: /^hide\s+(?<actor>\w+)(?:\s+(?<effect>\w+))?/,
 
     // ── Diálogo y narración ───────────────────────────────────────────────────
-
-    // actor:pose "texto" [vo_id]
+    // valeria:neutral "Texto del diálogo."
+    // valeria:triste  "Texto." [001]
     DIALOGUE: /^(?<actor>\w+):(?<pose>\w+)\s+"(?<text>[^"]+)"(?:\s+\[(?<vo>\w+)\])?/s,
 
-    // narrate "texto de narración"
+    // narrate "Texto de narración sin personaje."
     NARRATE: /^narrate\s+"(?<text>[^"]+)"/,
 
     // ── Escena ────────────────────────────────────────────────────────────────
-
-    // bg.set fondo [efecto:tiempo]
+    // bg.set forest
+    // bg.set mansion fade 2s
+    // bg.set void fade:500ms
     BG_COMMAND: /^bg\.set\s+(?<target>\w+)(?:\s+(?<effect>\w+)(?:[:\s](?<time>[\d.]+s?))?)?/,
 
     // ── Audio ─────────────────────────────────────────────────────────────────
-
-    // audio.bgm play[track] vol:0.5
-    // audio.se  play[explosion] vol:0.8
+    // audio.bgm play[track_01]
+    // audio.bgm play[track_01] vol:0.4
+    // audio.se  play[rain_ambience] 0.7
     AUDIO_COMMAND: /^audio\.(?<audioType>bgm|se)\s+(?<action>\w+)\[(?<param>[^\]]+)\](?:\s+(?:vol:)?(?<vol>[\d.]+))?/,
 
     // ── Control de flujo ──────────────────────────────────────────────────────
-
-    // wait 2s  |  wait 500ms
+    // wait 2s  |  wait 500ms  |  wait 1.5s
     WAIT: /^wait\s+(?<duration>\d+(?:\.\d+)?(?:s|ms))/,
 
     // puzzle P01 pass:"¡Lo lograste!" fail:"Casi. Sigamos."
     PUZZLE: /^puzzle\s+(?<puzzleId>\w+)\s+pass:"(?<passText>[^"]+)"\s+fail:"(?<failText>[^"]+)"/,
 
     // goto cap01/scene_02
-    // Soporta rutas con slashes para organización por capítulo/escena.
-    // Ejemplos válidos: goto intro, goto cap01/scene_02, goto cap02/final
-    GOTO: /^goto\s+(?<target>[\w/]+)/,
+    // goto cap02/scene_01 fade:black
+    // goto cap02/scene_01 fade:white
+    GOTO: /^goto\s+(?<target>[\w/]+)(?:\s+fade:(?<fadeColor>black|white))?/,
 
-    // ── Efectos de pantalla ──────────────────────────────────────────────────
-    //
+    // ── Efectos de pantalla ───────────────────────────────────────────────────
     // fx shake 0.4s
-    // fx flash white 0.3s
-    // fx flash black 0.5s
-    // fx vignette on
-    // fx vignette off
-    //
-    // shake y flash tienen duración obligatoria (s o ms).
-    // vignette es un toggle instantáneo — on | off.
-    FX_SHAKE:   /^fx\s+shake\s+(?<duration>\d+(?:\.\d+)?(?:s|ms))/,
-    FX_FLASH:   /^fx\s+flash\s+(?<color>white|black)\s+(?<duration>\d+(?:\.\d+)?(?:s|ms))/,
-    FX_VIGNETTE:/^fx\s+vignette\s+(?<state>on|off)/,
+    FX_SHAKE: /^fx\s+shake\s+(?<duration>\d+(?:\.\d+)?(?:s|ms))/,
+
+    // fx flash white 0.3s  |  fx flash black 0.5s
+    FX_FLASH: /^fx\s+flash\s+(?<color>white|black)\s+(?<duration>\d+(?:\.\d+)?(?:s|ms))/,
+
+    // fx vignette on  |  fx vignette off
+    FX_VIGNETTE: /^fx\s+vignette\s+(?<state>on|off)/,
 
     // ── Estado del juego ──────────────────────────────────────────────────────
-
-    // set flag.key = value
+    // set flag.cap01_completo = true
+    // set flag.intentos = 3
     SET_FLAG: /^set\s+flag\.(?<key>\w+)\s*=\s*(?<value>true|false|\d+(?:\.\d+)?|\w+)/,
 
-    // set inventory.add item_key
+    // set inventory.add llave_maestra
     INVENTORY_ADD: /^set\s+inventory\.add\s+(?<item>\w+)/,
 
-    // set inventory.remove item_key
+    // set inventory.remove llave_maestra
     INVENTORY_REMOVE: /^set\s+inventory\.remove\s+(?<item>\w+)/,
 
+    // ── Galería ───────────────────────────────────────────────────────────────
+    // unlock cg_01
+    // unlock cg_reunion title:"La reunión"
+    UNLOCK: /^unlock\s+(?<cgId>\w+)(?:\s+title:"(?<title>[^"]+)")?/,
+
     // ── Condicionales ─────────────────────────────────────────────────────────
-    //
-    // Comparadores soportados: == != > < >= <=
-    //
-    // if flag.key == value
-    // if flag.key > 3
+    // Operadores soportados: == != > < >= <=
+    // if flag.miki_confio == true
+    // if flag.intentos > 3
     IF_FLAG: /^if\s+flag\.(?<key>\w+)\s*(?<op>==|!=|>=|<=|>|<)\s*(?<value>true|false|\d+(?:\.\d+)?|\w+)/,
 
-    // if inventory.has item_key
+    // if inventory.has llave_maestra
     IF_INVENTORY: /^if\s+inventory\.has\s+(?<item>\w+)/,
 
-    // else
-    ELSE: /^else$/,
-
-    // endif
-    ENDIF:   /^endif$/,
-    UNLOCK:  /^unlock\s+(?<cgId>\w+)(?:\s+title:"(?<title>[^"]+)")?/,
+    ELSE:  /^else$/,
+    ENDIF: /^endif$/,
 };

--- a/src/core/parser/Parser.js
+++ b/src/core/parser/Parser.js
@@ -1,197 +1,250 @@
 // src/core/parser/Parser.js
-//
-// PATRÓN: Table-Driven Parsing
-//
-// Las reglas viven en PARSE_RULES como datos, no como código.
-// El método parse() es un loop genérico que nunca necesita modificarse.
-//
-// PARA AÑADIR UNA REGLA NUEVA:
-//   1. Añadir el regex en Grammar.js
-//   2. Añadir una entrada en PARSE_RULES (aquí abajo)
-//   3. Añadir el case en Engine.js execute()
-//   — parse() no se toca.
 
 import { KDN_GRAMMAR } from './Grammar.js';
 
-// ─── Tabla de reglas ──────────────────────────────────────────────────────────
-//
-// Campos:
-//   regex     {RegExp}   — patrón a matchear contra la línea
-//   type      {string}   — tipo de instrucción que produce
-//   transform {Function} — (opcional) transforma match.groups antes de guardar.
-//                          Si no se define, se usa match.groups directamente.
-//
-// ORDEN: más específico primero.
-//   - INVENTORY_ADD y INVENTORY_REMOVE van antes que SET_FLAG (ambas empiezan con 'set')
-//   - NARRATE va antes que DIALOGUE (no tiene actor:pose, pero el regex no colisiona)
-//   - PUZZLE y GOTO van antes que GOTO para evitar prefijos comunes
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
 
+/**
+ * @typedef {Object} ParseRule
+ * @property {RegExp}                               regex
+ * @property {string}                               type
+ * @property {((groups: Record<string,string>) => Record<string,*>)|undefined} transform
+ */
+
+/**
+ * @typedef {Object} RawInstruction
+ * @property {string} type
+ * @property {number} line
+ */
+
+/**
+ * @typedef {Object} ConditionalFrame
+ * @property {number}  jumpIdx  - Índice en `out` del COND_JUMP o JUMP pendiente
+ * @property {boolean} hasElse  - Si ya se procesó un ELSE para este bloque
+ */
+
+// ─── Tabla de reglas ──────────────────────────────────────────────────────────
+
+/**
+ * Reglas de parseo en orden de aplicación.
+ *
+ * El orden importa — las reglas más específicas van primero:
+ * - INVENTORY_ADD y INVENTORY_REMOVE antes que SET_FLAG (ambas empiezan con `set`)
+ * - NARRATE antes que DIALOGUE (distintos prefijos, no colisionan)
+ *
+ * Para añadir una instrucción nueva: añadir una entrada aquí y el case en Engine.js.
+ *
+ * @type {ParseRule[]}
+ */
 const PARSE_RULES = [
 
-    // ── Personajes ────────────────────────────────────────────────────────────
+    // ── Personajes ─────────────────────────────────────────────────────────
     {
         regex:     KDN_GRAMMAR.PAWN_INSTANTIATE,
         type:      'PAWN_LOAD',
-        transform: (g) => ({ names: g.names.split(',').map(n => n.trim()) }),
+        transform: (groups) => ({ names: groups.names.split(',').map(name => name.trim()) }),
     },
     { regex: KDN_GRAMMAR.SHOW, type: 'SPRITE_SHOW' },
     { regex: KDN_GRAMMAR.HIDE, type: 'SPRITE_HIDE' },
 
-    // ── Diálogo y narración ───────────────────────────────────────────────────
+    // ── Diálogo y narración ────────────────────────────────────────────────
     { regex: KDN_GRAMMAR.DIALOGUE, type: 'DIALOGUE' },
     { regex: KDN_GRAMMAR.NARRATE,  type: 'NARRATE'  },
 
-    // ── Escena y audio ────────────────────────────────────────────────────────
+    // ── Escena y audio ─────────────────────────────────────────────────────
     { regex: KDN_GRAMMAR.BG_COMMAND,    type: 'BG_CHANGE' },
     { regex: KDN_GRAMMAR.AUDIO_COMMAND, type: 'AUDIO'     },
 
-    // ── Control de flujo ──────────────────────────────────────────────────────
+    // ── Control de flujo ───────────────────────────────────────────────────
     { regex: KDN_GRAMMAR.WAIT,   type: 'WAIT'   },
     { regex: KDN_GRAMMAR.PUZZLE, type: 'PUZZLE' },
     { regex: KDN_GRAMMAR.GOTO,   type: 'GOTO'   },
 
-    // ── Estado (orden: más específico primero dentro del grupo 'set') ─────────
+    // ── Efectos de pantalla ────────────────────────────────────────────────
+    { regex: KDN_GRAMMAR.FX_SHAKE,    type: 'FX_SHAKE'    },
+    { regex: KDN_GRAMMAR.FX_FLASH,    type: 'FX_FLASH'    },
+    { regex: KDN_GRAMMAR.FX_VIGNETTE, type: 'FX_VIGNETTE' },
+
+    // ── Estado — más específico primero dentro del grupo `set` ────────────
     { regex: KDN_GRAMMAR.INVENTORY_ADD,    type: 'INVENTORY_ADD'    },
     { regex: KDN_GRAMMAR.INVENTORY_REMOVE, type: 'INVENTORY_REMOVE' },
     { regex: KDN_GRAMMAR.SET_FLAG,         type: 'SET_FLAG'         },
     { regex: KDN_GRAMMAR.UNLOCK,           type: 'UNLOCK'           },
 
-    // ── Efectos de pantalla ──────────────────────────────────────────────────────
-    { regex: KDN_GRAMMAR.FX_SHAKE,    type: 'FX_SHAKE'    },
-    { regex: KDN_GRAMMAR.FX_FLASH,    type: 'FX_FLASH'    },
-    { regex: KDN_GRAMMAR.FX_VIGNETTE, type: 'FX_VIGNETTE' },
-
-    // ── Condicionales (marcadores de bloque — el segundo pase los compila a saltos) ──
+    // ── Condicionales — compilados a saltos en el segundo pase ────────────
     { regex: KDN_GRAMMAR.IF_FLAG,      type: 'IF_FLAG'      },
     { regex: KDN_GRAMMAR.IF_INVENTORY, type: 'IF_INVENTORY' },
     { regex: KDN_GRAMMAR.ELSE,         type: 'ELSE'         },
     { regex: KDN_GRAMMAR.ENDIF,        type: 'ENDIF'        },
 ];
 
-// ─── Parser ───────────────────────────────────────────────────────────────────
+// ─── KParser ──────────────────────────────────────────────────────────────────
 
+/**
+ * Parser Table-Driven para scripts Koedan (.dan).
+ *
+ * Proceso en dos pases:
+ *   1. **Match** — cada línea se compara contra `PARSE_RULES` en orden,
+ *      produciendo un array plano de instrucciones tipadas.
+ *   2. **Resolve** — los marcadores `IF/ELSE/ENDIF` se convierten en
+ *      instrucciones de salto (`COND_JUMP` / `JUMP`) con índices absolutos.
+ *      El Engine ejecuta saltos directamente sin conocer la estructura de bloques.
+ *
+ * Para añadir una instrucción nueva: solo tocar `Grammar.js`, `PARSE_RULES` y `Engine.js`.
+ * Este método `parse()` nunca necesita modificarse.
+ *
+ * @example
+ * const parser = new KParser();
+ * const instructions = parser.parse(rawScriptText);
+ * await engine.loadScript(instructions);
+ */
 export class KParser {
 
+    /**
+     * Parsea un script .dan completo y devuelve el array de instrucciones listo
+     * para ser ejecutado por el Engine.
+     *
+     * @param   {string}            rawScript - Contenido completo del archivo .dan
+     * @returns {RawInstruction[]}
+     */
     parse(rawScript) {
-        const lines = rawScript.trim().split('\n');
-        console.log(`[Parser] Procesando ${lines.length} líneas...`);
+        const scriptLines = rawScript.trim().split('\n');
+        console.log(`[Parser] Procesando ${scriptLines.length} líneas...`);
 
-        // ── Pase 1: matchear cada línea contra las reglas ─────────────────────
-        const raw = [];
-        lines.forEach((line, index) => {
-            const trimmed = line.trim();
-            if (!trimmed || trimmed.startsWith('#')) return;
+        const rawInstructions    = this.#matchAllLines(scriptLines);
+        const compiledInstructions = this.#compileConditionalBlocks(rawInstructions);
 
-            const instruction = this._matchLine(trimmed, index);
-            raw.push(instruction);
+        console.log('[Parser] Árbol generado:', compiledInstructions);
+        return compiledInstructions;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PASE 1 — Match de líneas
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @param   {string[]}          lines
+     * @returns {RawInstruction[]}
+     */
+    #matchAllLines(lines) {
+        const instructions = [];
+
+        lines.forEach((rawLine, lineIndex) => {
+            const trimmedLine = rawLine.trim();
+            if (!trimmedLine || trimmedLine.startsWith('#')) return;
+
+            const instruction = this.#matchSingleLine(trimmedLine, lineIndex);
+            instructions.push(instruction);
 
             if (instruction.type === 'UNKNOWN') {
-                console.warn(`[Parser] Línea ${index + 1} no reconocida: "${trimmed}"`);
+                console.warn(`[Parser] Línea ${lineIndex + 1} no reconocida: "${trimmedLine}"`);
             }
         });
 
-        // ── Pase 2: resolver bloques if/else/endif en saltos con índices ──────
-        const instructions = this._resolveBlocks(raw);
-
-        console.log('[Parser] Árbol generado:', instructions);
         return instructions;
     }
 
     /**
-     * Convierte los marcadores IF/ELSE/ENDIF en instrucciones de salto con
-     * índices precalculados. El engine no necesita saber nada de bloques.
+     * Compara una línea contra todas las reglas en orden.
+     * Devuelve la primera que coincida, o tipo UNKNOWN si ninguna aplica.
      *
-     * IF_FLAG   { condition } → COND_JUMP { condition, targetIndex }
-     *   ... cuerpo del if ...
-     * ELSE                    → JUMP      { targetIndex }
-     *   ... cuerpo del else ...
-     * ENDIF                   → (eliminado)
-     *
-     * Si no hay ELSE:
-     * IF_FLAG   { condition } → COND_JUMP { condition, targetIndex: índice tras ENDIF }
-     *   ... cuerpo ...
-     * ENDIF                   → (eliminado)
-     *
-     * Los bloques pueden anidarse.
+     * @param   {string}          trimmedLine
+     * @param   {number}          lineIndex
+     * @returns {RawInstruction}
      */
-    _resolveBlocks(raw) {
-        const out   = [];
-        const stack = []; // stack de { jumpIndex, hasElse }
-
-        for (let i = 0; i < raw.length; i++) {
-            const inst = raw[i];
-
-            if (inst.type === 'IF_FLAG' || inst.type === 'IF_INVENTORY') {
-                // Emitir COND_JUMP con targetIndex pendiente (se rellena al encontrar ELSE/ENDIF)
-                const jumpInst = {
-                    type:        'COND_JUMP',
-                    condition:   inst,     // instrucción original con key/op/value
-                    targetIndex: -1,       // pendiente
-                    line:        inst.line,
-                };
-                stack.push({ jumpIdx: out.length, hasElse: false });
-                out.push(jumpInst);
-
-            } else if (inst.type === 'ELSE') {
-                const frame = stack[stack.length - 1];
-                if (!frame) {
-                    console.error(`[Parser] ELSE sin IF en línea ${inst.line + 1}`);
-                    continue;
-                }
-                // El COND_JUMP del IF ahora apunta al índice siguiente (tras este JUMP)
-                // Emitir un JUMP incondicional para saltar el cuerpo del else
-                const jumpInst = {
-                    type:        'JUMP',
-                    targetIndex: -1,   // pendiente — se rellena al encontrar ENDIF
-                    line:        inst.line,
-                };
-                // Fijar target del COND_JUMP al índice que tendrá el JUMP + 1
-                out[frame.jumpIdx].targetIndex = out.length + 1;
-                frame.jumpIdx  = out.length; // ahora rastreamos el JUMP del else
-                frame.hasElse  = true;
-                out.push(jumpInst);
-
-            } else if (inst.type === 'ENDIF') {
-                const frame = stack.pop();
-                if (!frame) {
-                    console.error(`[Parser] ENDIF sin IF en línea ${inst.line + 1}`);
-                    continue;
-                }
-                // Fijar el target del último jump pendiente al índice actual (tras endif)
-                out[frame.jumpIdx].targetIndex = out.length;
-                // ENDIF no emite instrucción — se elimina
-
-            } else {
-                out.push(inst);
-            }
-        }
-
-        if (stack.length > 0) {
-            console.error(`[Parser] ${stack.length} bloque(s) if sin cerrar con endif.`);
-        }
-
-        return out;
-    }
-
-    /**
-     * Intenta matchear una línea contra todas las reglas en orden.
-     * Devuelve la instrucción resultante, o tipo UNKNOWN si ninguna aplica.
-     * @param   {string} line  - Línea ya trimmed
-     * @param   {number} index - Número de línea (para debug)
-     * @returns {object}       - Instrucción { type, ...data, line }
-     */
-    _matchLine(line, index) {
+    #matchSingleLine(trimmedLine, lineIndex) {
         for (const rule of PARSE_RULES) {
-            const match = line.match(rule.regex);
+            const match = trimmedLine.match(rule.regex);
             if (!match) continue;
 
-            const data = rule.transform
+            const extractedData = rule.transform
                 ? rule.transform(match.groups)
                 : { ...match.groups };
 
-            return { type: rule.type, ...data, line: index };
+            return { type: rule.type, ...extractedData, line: lineIndex };
         }
 
-        return { type: 'UNKNOWN', raw: line, line: index };
+        return { type: 'UNKNOWN', raw: trimmedLine, line: lineIndex };
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PASE 2 — Compilación de bloques condicionales
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Convierte los marcadores `IF/ELSE/ENDIF` en instrucciones de salto
+     * con índices absolutos precalculados.
+     *
+     * Resultado para un bloque `if/else/endif`:
+     *   IF_FLAG   → COND_JUMP { targetIndex: índice del JUMP+1 }
+     *   ...cuerpo del if...
+     *   ELSE      → JUMP      { targetIndex: índice tras ENDIF }
+     *   ...cuerpo del else...
+     *   ENDIF     → (eliminado)
+     *
+     * Resultado para un bloque `if/endif` sin else:
+     *   IF_FLAG   → COND_JUMP { targetIndex: índice tras ENDIF }
+     *   ...cuerpo...
+     *   ENDIF     → (eliminado)
+     *
+     * @param   {RawInstruction[]} rawInstructions
+     * @returns {RawInstruction[]}
+     */
+    #compileConditionalBlocks(rawInstructions) {
+        const compiledOutput       = [];
+        const pendingJumpsStack    = []; // @type {ConditionalFrame[]}
+
+        for (const instruction of rawInstructions) {
+
+            if (instruction.type === 'IF_FLAG' || instruction.type === 'IF_INVENTORY') {
+                const conditionalJump = {
+                    type:        'COND_JUMP',
+                    condition:   instruction,
+                    targetIndex: -1, // se rellena al encontrar ELSE o ENDIF
+                    line:        instruction.line,
+                };
+                pendingJumpsStack.push({ jumpIdx: compiledOutput.length, hasElse: false });
+                compiledOutput.push(conditionalJump);
+
+            } else if (instruction.type === 'ELSE') {
+                const currentFrame = pendingJumpsStack[pendingJumpsStack.length - 1];
+                if (!currentFrame) {
+                    console.error(`[Parser] ELSE sin IF en línea ${instruction.line + 1}`);
+                    continue;
+                }
+
+                const unconditionalJump = {
+                    type:        'JUMP',
+                    targetIndex: -1, // se rellena al encontrar ENDIF
+                    line:        instruction.line,
+                };
+
+                // El COND_JUMP del IF apunta al índice siguiente al JUMP del ELSE
+                compiledOutput[currentFrame.jumpIdx].targetIndex = compiledOutput.length + 1;
+                currentFrame.jumpIdx = compiledOutput.length;
+                currentFrame.hasElse = true;
+                compiledOutput.push(unconditionalJump);
+
+            } else if (instruction.type === 'ENDIF') {
+                const currentFrame = pendingJumpsStack.pop();
+                if (!currentFrame) {
+                    console.error(`[Parser] ENDIF sin IF en línea ${instruction.line + 1}`);
+                    continue;
+                }
+
+                // El último jump pendiente apunta al índice actual (tras el ENDIF)
+                compiledOutput[currentFrame.jumpIdx].targetIndex = compiledOutput.length;
+                // ENDIF no emite instrucción — se elimina del output
+
+            } else {
+                compiledOutput.push(instruction);
+            }
+        }
+
+        if (pendingJumpsStack.length > 0) {
+            console.error(`[Parser] ${pendingJumpsStack.length} bloque(s) if sin cerrar con endif.`);
+        }
+
+        return compiledOutput;
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,106 +1,117 @@
 // src/main.js
-// Bootstrap de PRODUCCIÓN.
+// Bootstrap de producción — instancia todos los módulos y arranca el juego.
 
-import { db }             from './core/database/db.js';
-import { seedProductionDB } from './core/database/seed.js';
-import { Dramaturge }    from './core/Engine.js';
-import { KParser }       from './core/parser/Parser.js';
-import { Renderer }      from './modules/Renderer.js';
-import { AudioManager }         from './modules/Audio.js';
-import { GameState }     from './core/State.js';
-import { SaveManager }   from './core/SaveManager.js';
-import { PuzzleSystem }  from './modules/PuzzleSystem.js';
-import { SceneManager }  from './core/SceneManager.js';
-import { MenuSystem }    from './modules/MenuSystem.js';
+import { db }                from './core/database/db.js';
+import { seedProductionDB }  from './core/database/seed.js';
+import { Dramaturge }        from './core/Engine.js';
+import { KParser }           from './core/parser/Parser.js';
+import { Renderer }          from './modules/Renderer.js';
+import { AudioManager }      from './modules/Audio.js';
+import { GameState }         from './core/State.js';
+import { SaveManager }       from './core/SaveManager.js';
+import { PuzzleSystem }      from './modules/PuzzleSystem.js';
+import { SceneManager }      from './core/SceneManager.js';
+import { MenuSystem }        from './modules/MenuSystem.js';
 
-const renderer    = new Renderer();
-const audio       = new AudioManager();
-const parser      = new KParser();
-const state       = new GameState();
-const saveManager = new SaveManager(db);
-const engine      = new Dramaturge(db, renderer, audio, state, saveManager);
+// ─── Instanciación de módulos ─────────────────────────────────────────────────
+
+const renderer     = new Renderer();
+const audio        = new AudioManager();
+const parser       = new KParser();
+const initialState = new GameState();
+const saveManager  = new SaveManager(db);
+const engine       = new Dramaturge(db, renderer, audio, initialState, saveManager);
 const sceneManager = new SceneManager(engine, parser);
+const puzzleSystem = new PuzzleSystem(db, initialState);
 
-// Resolvers inyectados — el Engine no importa estos módulos directamente
-const puzzleSystem = new PuzzleSystem(db, state);
-engine.puzzleResolver = (id)     => puzzleSystem.open(id);
-engine.sceneLoader    = (target, fadeColor) => sceneManager.goto(target, fadeColor);
+// ─── Inyección de callbacks externos ──────────────────────────────────────────
+// El Engine no importa PuzzleSystem ni SceneManager directamente —
+// los recibe como callbacks para evitar dependencias circulares.
 
-// Menú principal — orquesta el flujo completo
+engine.puzzleResolver = (puzzleId)           => puzzleSystem.open(puzzleId);
+engine.sceneLoader    = (target, fadeColor)  => sceneManager.goto(target, fadeColor);
+
+// ─── Menú principal ───────────────────────────────────────────────────────────
+
 const menu = new MenuSystem({
     engine,
     saveManager,
     sceneManager,
     audio,
     startScene:   'cap01/scene_01',
-    gameTitle:    'DRAMATURGE',     // ← cambiar por el título del juego
+    gameTitle:    'DRAMATURGE',
     gameSubtitle: 'Cada secreto tiene su precio',
 });
 
-// ── InputGate — punto de entrada único para todo input del jugador ──────────
+// ─── InputGate ────────────────────────────────────────────────────────────────
+//
+// Punto de entrada único para todo input del jugador (clic y teclado).
 //
 // Garantías:
 //   1. Solo pasa si el estado del menú es IN_GAME
-//   2. No pasa si hay paneles del menú abiertos (slots, audio, modal)
-//   3. Cooldown de 60ms — descarta dobles clicks/teclas del mismo gesto
-//   4. No pasa si click fue sobre un elemento de UI (botón, hud, menú)
+//   2. No pasa si el backlog está abierto
+//   3. No pasa si hay paneles del menú abiertos (slots, audio, modal)
+//   4. Cooldown de 60ms — descarta dobles clicks y rebotes de teclado
 //
-// Engine.next() tiene su propio guard interno (_nextRunning) para re-entrancia
-// en llamadas async, pero este gate es la primera línea de defensa.
+// Engine.next() tiene su propio guard interno (#isAdvancing) para re-entrancia
+// async, pero el InputGate es la primera línea de defensa.
 
-const S = MenuSystem.STATES ?? {};
+const INPUT_COOLDOWN_MS = 60;
+let lastInputTimestamp  = 0;
 
-let _lastInputTs = 0;
-
-function inputGate(fromUI = false) {
-    // Solo en IN_GAME
+function inputGate() {
     if (menu.state !== 'IN_GAME') return;
-
-    // No si hay panel abierto — incluido el backlog
     if (menu.backlogOpen) return;
-    const panelOpen = document.querySelector(
+
+    const panelIsOpen = document.querySelector(
         '#dm-slot-panel:not(.dm-hidden), #dm-audio-panel:not(.dm-hidden), #dm-modal:not(.dm-hidden)'
     );
-    if (panelOpen) return;
+    if (panelIsOpen) return;
 
-    // Cooldown de 60ms (cubre doble-tap y bounce de teclado)
     const now = Date.now();
-    if (now - _lastInputTs < 60) return;
-    _lastInputTs = now;
+    if (now - lastInputTimestamp < INPUT_COOLDOWN_MS) return;
+    lastInputTimestamp = now;
 
     engine.next();
 }
 
 document.getElementById('click-zone')
-    ?.addEventListener('click', (e) => {
-        // Ignorar si el clic fue sobre un botón o elemento de UI
-        if (e.target.closest('button, a, input, #hud, #pause-menu, #main-menu, [id^="dm-"]')) return;
+    ?.addEventListener('click', (clickEvent) => {
+        const clickedOnUiElement = clickEvent.target.closest(
+            'button, a, input, #hud, #pause-menu, #main-menu, [id^="dm-"]'
+        );
+        if (clickedOnUiElement) return;
         inputGate();
     });
 
-document.addEventListener('keydown', (e) => {
-    if (e.code !== 'Space' && e.code !== 'Enter') return;
-    const tag = document.activeElement?.tagName;
-    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'BUTTON' || tag === 'A') return;
-    e.preventDefault();
+document.addEventListener('keydown', (keyboardEvent) => {
+    if (keyboardEvent.code !== 'Space' && keyboardEvent.code !== 'Enter') return;
+
+    const focusedTag = document.activeElement?.tagName;
+    if (['INPUT', 'TEXTAREA', 'BUTTON', 'A'].includes(focusedTag)) return;
+
+    keyboardEvent.preventDefault();
     inputGate();
 });
 
-async function init() {
-    await renderer.init();
-    await seedProductionDB(db); // no-op si la DB ya tiene datos
-    await menu.init();
-}
+// ─── Service Worker ───────────────────────────────────────────────────────────
+// Solo en producción — en desarrollo interferiría con el HMR de Vite.
 
-init();
-// ── Service Worker — registro PWA ─────────────────────────────────────────────
-// Solo en producción y si el navegador lo soporta.
-// En desarrollo (npm run dev) el SW no se registra para no interferir con HMR.
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
     window.addEventListener('load', () => {
         navigator.serviceWorker
             .register(`${import.meta.env.BASE_URL}sw.js`)
-            .then((reg) => console.log('[SW] Registrado:', reg.scope))
-            .catch((err) => console.warn('[SW] Error al registrar:', err));
+            .then(registration => console.log('[SW] Registrado:', registration.scope))
+            .catch(error      => console.warn('[SW] Error al registrar:', error));
     });
 }
+
+// ─── Arranque ─────────────────────────────────────────────────────────────────
+
+async function initializeGame() {
+    await renderer.init();
+    await seedProductionDB(db);
+    await menu.init();
+}
+
+initializeGame();

--- a/src/modules/Audio.js
+++ b/src/modules/Audio.js
@@ -1,308 +1,288 @@
 // src/modules/Audio.js
-//
-// CANALES DE AUDIO:
-//   bgm   → Música de fondo. Loop continuo. Soporta fade out.
-//   voice → Voz del personaje activo. Se interrumpe al cambiar de línea.
-//   se    → Efectos de sonido puntuales (one-shot).
-//
-// Usa HTMLAudioElement (sin dependencias). Suficiente para novelas visuales.
-// Si en el futuro necesitas audio posicional o síntesis, migrar a Web Audio API.
 
-// Formatos de audio soportados en orden de preferencia.
-const AUDIO_FORMATS = ['mp3', 'ogg'];
+import { Howl, Howler } from 'howler';
 
-// Rutas base por canal.
-// Si el param que viene del script ya empieza con '/', se usa directamente.
-// Si no (ej: 'track_01'), se le añade el prefijo del canal.
-const AUDIO_BASE = {
-    bgm:   `${import.meta.env.BASE_URL}assets/audio/bgm/`,
-    voice: `${import.meta.env.BASE_URL}assets/audio/voice/`,
-    se:    `${import.meta.env.BASE_URL}assets/audio/se/`,
+// ─── Constantes ───────────────────────────────────────────────────────────────
+
+const AUDIO_BASE_URL = import.meta.env.BASE_URL;
+
+const AUDIO_CHANNEL_PATHS = {
+    bgm:   `${AUDIO_BASE_URL}assets/audio/bgm/`,
+    voice: `${AUDIO_BASE_URL}assets/audio/voice/`,
+    se:    `${AUDIO_BASE_URL}assets/audio/se/`,
 };
 
+/** Formatos en orden de preferencia — Howler elige el primero compatible */
+const SUPPORTED_AUDIO_FORMATS = ['mp3', 'ogg'];
+
+const BGM_DUCK_FACTOR_VOICE  = 0.35; // BGM baja al 35% mientras habla un personaje
+const BGM_DUCK_FACTOR_PAUSED = 0.20; // BGM baja al 20% al abrir el menú de pausa
+
+const DUCK_FADE_VOICE_MS  = 220;
+const DUCK_FADE_RESUME_MS = 400;
+const DUCK_FADE_PAUSE_MS  = 300;
+const BGM_STOP_FADE_MS    = 1000;
+
+// ─── Typedefs ─────────────────────────────────────────────────────────────────
+
 /**
- * Resuelve la ruta de audio intentando múltiples formatos.
- * Devuelve la primera URL que el navegador puede reproducir,
- * o el path original si ya tiene extensión o ninguno funciona.
- * @param   {string} path
- * @returns {Promise<string>}
+ * @typedef {'bgm' | 'voice' | 'se'} AudioChannel
  */
+
 /**
- * Resuelve la ruta de audio:
- *   1. Si el param ya es una ruta absoluta ('/assets/...'), se usa directo.
- *   2. Si no, se añade el prefijo del canal (bgm/voice/se).
- *   3. Si no tiene extensión, se prueba mp3 → ogg via HEAD request.
- * @param {string} param   - Valor del param del script ('.ems')
- * @param {string} channel - 'bgm' | 'voice' | 'se'
+ * @typedef {Object} ChannelVolumes
+ * @property {number} bgm   - 0.0 a 1.0
+ * @property {number} voice - 0.0 a 1.0
+ * @property {number} se    - 0.0 a 1.0
  */
-async function resolveAudioPath(param, channel = 'bgm') {
-    // Si ya es ruta absoluta, respetar tal cual
-    const path = param.startsWith('/') ? param : `${AUDIO_BASE[channel]}${param}`;
 
-    const hasExt = AUDIO_FORMATS.some(f => path.toLowerCase().endsWith(`.${f}`));
-    if (hasExt) return path;
+// ─── AudioManager ─────────────────────────────────────────────────────────────
 
-    for (const fmt of AUDIO_FORMATS) {
-        const candidate = `${path}.${fmt}`;
-        try {
-            const res = await fetch(candidate, { method: 'HEAD' });
-            if (res.ok) return candidate;
-        } catch { /* continuar */ }
-    }
-
-    return `${path}.mp3`; // fallback
-}
-
+/**
+ * Gestor de audio del motor. Tres canales independientes: BGM, voz y efectos.
+ *
+ * Internamente usa Howler.js (Web Audio API con fallback a HTML5 Audio).
+ * La API pública es idéntica hacia el Engine y el MenuSystem — ningún módulo
+ * externo necesita saber que existe Howler.
+ *
+ * Canales:
+ * - `bgm`   — música de fondo, loop continuo, soporta fade y ducking
+ * - `voice` — voz del personaje activo, interrumpe la anterior al cambiar
+ * - `se`    — efectos de sonido puntuales (one-shot), no interrumpen nada
+ *
+ * Ducking:
+ * - Al reproducir voz: BGM baja al 35% con fade suave, sube al terminar
+ * - Al pausar el juego: BGM baja al 20% con fade, sube al reanudar
+ *
+ * @example
+ * const audio = new AudioManager();
+ * audio.unlock(); // llamar tras el primer gesto del usuario
+ * await audio.playBGM('track_01', 0.4);
+ * await audio.playVoice('VAL_001.mp3');
+ */
 export class AudioManager {
-    constructor() {
-        // Cada canal es un HTMLAudioElement independiente
-        this._bgm   = new Audio();
-        this._voice = new Audio();
-        this._se    = new Audio();
 
-        this._bgm.loop = true;
+    // ── Canal BGM ──────────────────────────────────────────────────────────
 
-        // Volúmenes por canal (0.0 → 1.0)
-        this._volumes = {
-            bgm:   0.5,
-            voice: 1.0,
-            se:    0.8,
-        };
+    /** @type {Howl|null} — instancia Howl activa del BGM actual */
+    #activeBgmHowl = null;
 
-        this._bgmFadeTimer = null; // referencia al intervalo de fade activo
+    /** @type {string|null} — nombre de pista activa para evitar recargas */
+    #activeBgmTrackName = null;
 
-        // Ducking: cuando hay voz activa, el BGM baja al % definido
-        this._bgmBaseVolume  = this._volumes.bgm; // volumen real sin duck
-        this._duckFactor     = 0.35; // BGM baja al 35% mientras habla un personaje
-        this._duckRafId      = null;
+    /**
+     * Volumen base del BGM sin ducking aplicado.
+     * El ducking opera sobre este valor, no sobre el volumen actual.
+     * @type {number}
+     */
+    #bgmBaseVolume = 0.5;
 
-        // Restaurar BGM cuando la voz termina
-        this._voice.addEventListener('ended', () => this._unduckBGM());
-        this._voice.addEventListener('pause', () => {
-            // Solo restaurar si fue pausa definitiva (src vacío = stop manual)
-            if (!this._voice.src) this._unduckBGM();
-        });
-    }
+    // ── Canales de voz y efectos ───────────────────────────────────────────
+
+    /** @type {Howl|null} */
+    #activeVoiceHowl = null;
+
+    /** @type {Howl|null} */
+    #activeSeHowl = null;
+
+    // ── Volúmenes por canal ────────────────────────────────────────────────
+
+    /** @type {ChannelVolumes} */
+    #channelVolumes = {
+        bgm:   0.5,
+        voice: 1.0,
+        se:    0.8,
+    };
 
     // ─────────────────────────────────────────────────────────────────────────
     // API PÚBLICA
     // ─────────────────────────────────────────────────────────────────────────
 
     /**
-     * Reproduce música de fondo en loop.
-     * Si ya hay una pista activa, la reemplaza.
-     * @param {string} path   - Ruta al archivo (ej: 'assets/audio/bgm/forest.mp3')
-     * @param {number} volume - Volumen inicial (0.0–1.0). Usa el canal por defecto si no se pasa.
+     * Desbloquea el contexto de audio del navegador.
+     * Los navegadores modernos requieren un gesto del usuario antes de reproducir.
+     * Llamar desde el handler del primer clic del jugador.
      */
-    async playBGM(path, volume) {
-        const resolved = await resolveAudioPath(path, 'bgm');
-        if (this._bgm.src.endsWith(resolved) && !this._bgm.paused) return;
-
-        this._cancelFade();
-        this._bgm.src    = resolved;
-        this._bgmBaseVolume = volume ?? this._volumes.bgm;
-        this._bgm.volume    = this._bgmBaseVolume;
-        this._bgm.currentTime = 0;
-        this._bgm.play().catch(e => console.warn(`[Audio] BGM: ${e.message} (${resolved})`));
+    unlock() {
+        // Howler gestiona el desbloqueo internamente — este método existe
+        // para mantener compatibilidad con el contrato público anterior.
+        // Una llamada explícita a Howler.ctx?.resume() cubre edge cases.
+        Howler.ctx?.resume();
     }
 
     /**
-     * Detiene la BGM con fade out gradual.
-     * @param {number} durationMs - Duración del fade en milisegundos.
+     * Reproduce música de fondo en loop continuo.
+     * Si la misma pista ya está sonando, no hace nada.
+     * Si hay otra pista activa, la reemplaza inmediatamente.
+     *
+     * @param {string} trackName - Nombre del archivo sin extensión
+     * @param {number} [volume]  - Volumen (0.0–1.0). Usa el valor del canal si no se pasa.
      */
-    stopBGM(durationMs = 1000) {
-        if (this._bgm.paused) return;
-        this._fadeOut(this._bgm, durationMs, () => {
-            this._bgm.pause();
-            this._bgm.currentTime = 0;
+    async playBGM(trackName, volume) {
+        const targetVolume = volume ?? this.#channelVolumes.bgm;
+
+        if (this.#activeBgmTrackName === trackName && this.#activeBgmHowl?.playing()) return;
+
+        this.#stopBgmImmediately();
+
+        this.#bgmBaseVolume     = targetVolume;
+        this.#activeBgmTrackName = trackName;
+
+        this.#activeBgmHowl = new Howl({
+            src:    this.#buildSourceUrls(trackName, 'bgm'),
+            volume: targetVolume,
+            loop:   true,
+            onloaderror: (id, error) => {
+                console.error(`[Audio] BGM no encontrado: "${trackName}"`, error);
+            },
+        });
+
+        this.#activeBgmHowl.play();
+    }
+
+    /**
+     * Detiene el BGM con fade out gradual.
+     * @param {number} [fadeDurationMs]
+     */
+    stopBGM(fadeDurationMs = BGM_STOP_FADE_MS) {
+        if (!this.#activeBgmHowl?.playing()) return;
+        this.#activeBgmHowl.fade(this.#activeBgmHowl.volume(), 0, fadeDurationMs);
+        this.#activeBgmHowl.once('fade', () => {
+            this.#activeBgmHowl?.stop();
+            this.#activeBgmHowl     = null;
+            this.#activeBgmTrackName = null;
         });
     }
 
     /**
-     * Reproduce la línea de voz de un personaje.
-     * Interrumpe cualquier voz anterior automáticamente.
-     * @param {string} path - Ruta al archivo (ej: 'assets/audio/voice/VAL_001.mp3')
+     * Reproduce una línea de voz. Interrumpe cualquier voz anterior.
+     * Al terminar, restaura el BGM al volumen base (unduck).
+     *
+     * @param {string} voiceFilename - Nombre del archivo con extensión (ej: 'VAL_001.mp3')
      */
-    async playVoice(path) {
-        const resolved = await resolveAudioPath(path, 'voice');
-        this._voice.pause();
-        this._voice.src    = resolved;
-        this._voice.volume = this._volumes.voice;
-        this._voice.currentTime = 0;
-        this._voice.play()
-            .then(() => this._duckBGM()) // ducking solo si la voz arrancó bien
-            .catch(e => console.warn(`[Audio] Voz: ${e.message} (${resolved})`));
+    async playVoice(voiceFilename) {
+        this.#activeVoiceHowl?.stop();
+
+        const voicePath = `${AUDIO_CHANNEL_PATHS.voice}${voiceFilename}`;
+
+        this.#activeVoiceHowl = new Howl({
+            src:    [voicePath],
+            volume: this.#channelVolumes.voice,
+            onplay: () => this.#duckBgmForVoice(),
+            onend:  () => this.#unduckBgmAfterVoice(),
+            onstop: () => this.#unduckBgmAfterVoice(),
+            onloaderror: (id, error) => {
+                console.warn(`[Audio] Voz no encontrada: "${voiceFilename}"`, error);
+            },
+        });
+
+        this.#activeVoiceHowl.play();
     }
 
     /**
      * Reproduce un efecto de sonido (one-shot).
-     * No interrumpe ni la BGM ni la voz.
-     * @param {string} path   - Ruta al archivo
-     * @param {number} volume - Volumen específico para este SE
+     * No interrumpe el BGM ni la voz.
+     *
+     * @param {string} effectName - Nombre del archivo sin extensión
+     * @param {number} [volume]   - Volumen específico para este efecto
      */
-    async playSE(path, volume) {
-        const resolved = await resolveAudioPath(path, 'se');
-        this._se.pause();
-        this._se.src    = resolved;
-        this._se.volume = volume ?? this._volumes.se;
-        this._se.currentTime = 0;
-        this._se.play().catch(e => console.warn(`[Audio] SE: ${e.message} (${resolved})`));
+    async playSE(effectName, volume) {
+        this.#activeSeHowl?.stop();
+
+        this.#activeSeHowl = new Howl({
+            src:    this.#buildSourceUrls(effectName, 'se'),
+            volume: volume ?? this.#channelVolumes.se,
+            onloaderror: (id, error) => {
+                console.warn(`[Audio] Efecto no encontrado: "${effectName}"`, error);
+            },
+        });
+
+        this.#activeSeHowl.play();
     }
 
     /**
-     * Ajusta el volumen de un canal.
-     * @param {'bgm'|'voice'|'se'} channel
-     * @param {number}             value    - 0.0 a 1.0
+     * Ajusta el volumen de un canal y lo aplica inmediatamente.
+     * @param {AudioChannel} channel
+     * @param {number}       volume  - 0.0 a 1.0
      */
-    setVolume(channel, value) {
-        const clamped = Math.max(0, Math.min(1, value));
-        this._volumes[channel] = clamped;
+    setVolume(channel, volume) {
+        const clampedVolume = Math.max(0, Math.min(1, volume));
+        this.#channelVolumes[channel] = clampedVolume;
 
-        // Aplicar inmediatamente al elemento activo
         if (channel === 'bgm') {
-            this._bgmBaseVolume = clamped; // actualizar base para ducking
-            this._bgm.volume    = clamped;
+            this.#bgmBaseVolume = clampedVolume;
+            this.#activeBgmHowl?.volume(clampedVolume);
         }
-        if (channel === 'voice') this._voice.volume = clamped;
-        if (channel === 'se')    this._se.volume    = clamped;
+        if (channel === 'voice') this.#activeVoiceHowl?.volume(clampedVolume);
+        if (channel === 'se')    this.#activeSeHowl?.volume(clampedVolume);
     }
 
     /** Silencia todos los canales instantáneamente. */
     muteAll() {
-        this._bgm.muted   = true;
-        this._voice.muted = true;
-        this._se.muted    = true;
+        Howler.mute(true);
     }
 
-    /** Restaura el audio después de un mute. */
+    /** Restaura todos los canales tras un mute. */
     unmuteAll() {
-        this._bgm.muted   = false;
-        this._voice.muted = false;
-        this._se.muted    = false;
+        Howler.mute(false);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // DESBLOQUEO DE AUDIO
-    // ─────────────────────────────────────────────────────────────────────────
+    // ── Ducking de pausa ───────────────────────────────────────────────────
 
     /**
-     * Desbloquea el contexto de audio del navegador.
-     * Los navegadores modernos requieren un gesto del usuario antes de reproducir.
-     * Llamar desde el handler del clic de "Nueva Partida" / "Continuar".
-     */
-    unlock() {
-        // Reproducir y pausar inmediatamente un silencio — esto desbloquea el contexto
-        const silent = new Audio();
-        silent.play().catch(() => {}); // el catch es intencional
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // HELPERS PRIVADOS
-    // ─────────────────────────────────────────────────────────────────────────
-
-    /**
-     * Reduce el volumen de un elemento de audio gradualmente.
-     * @param {HTMLAudioElement} audioEl
-     * @param {number}           durationMs
-     * @param {Function}         onComplete - Callback al finalizar
-     */
-    _fadeOut(audioEl, durationMs, onComplete) {
-        this._cancelFade();
-        const startVolume = audioEl.volume;
-        const startTime   = performance.now();
-
-        const tick = () => {
-            const t = Math.min((performance.now() - startTime) / durationMs, 1);
-            // Ease-out para que el fade suene natural
-            audioEl.volume = startVolume * (1 - (t * t));
-            if (t < 1) {
-                this._bgmFadeTimer = requestAnimationFrame(tick);
-            } else {
-                audioEl.volume = 0;
-                this._bgmFadeTimer = null;
-                onComplete?.();
-            }
-        };
-        this._bgmFadeTimer = requestAnimationFrame(tick);
-    }
-
-    _cancelFade() {
-        if (this._bgmFadeTimer) {
-            cancelAnimationFrame(this._bgmFadeTimer);
-            this._bgmFadeTimer = null;
-        }
-    }
-
-    // ── Ducking helpers ───────────────────────────────────────────────────────
-
-    /**
-     * Duck suave al entrar en pausa — baja el BGM al 20% con ease-in.
-     * Más pronunciado que el duck de voz porque es una pausa activa del usuario.
+     * Baja el BGM al 20% al entrar en el menú de pausa.
+     * Más pronunciado que el ducking de voz — indica una pausa activa.
      */
     pauseDuck() {
-        if (this._bgm.paused) return;
-        cancelAnimationFrame(this._duckRafId);
-        const startVol  = this._bgm.volume;
-        const targetVol = this._bgmBaseVolume * 0.20;
-        const durationMs = 300;
-        const startTime  = performance.now();
-        const tick = () => {
-            const t = Math.min((performance.now() - startTime) / durationMs, 1);
-            const ease = t * t; // ease-in — baja rápido al principio
-            this._bgm.volume = startVol + (targetVol - startVol) * ease;
-            if (t < 1) this._duckRafId = requestAnimationFrame(tick);
-        };
-        this._duckRafId = requestAnimationFrame(tick);
+        if (!this.#activeBgmHowl?.playing()) return;
+        const targetVolume = this.#bgmBaseVolume * BGM_DUCK_FACTOR_PAUSED;
+        this.#activeBgmHowl.fade(this.#activeBgmHowl.volume(), targetVolume, DUCK_FADE_PAUSE_MS);
     }
 
-    /** Restaura el BGM al salir de pausa — ease-out cúbico. */
+    /** Restaura el BGM al salir del menú de pausa. */
     pauseUnduck() {
-        if (this._bgm.paused) return;
-        cancelAnimationFrame(this._duckRafId);
-        const startVol   = this._bgm.volume;
-        const targetVol  = this._bgmBaseVolume;
-        const durationMs = 500;
-        const startTime  = performance.now();
-        const tick = () => {
-            const t = Math.min((performance.now() - startTime) / durationMs, 1);
-            const ease = 1 - Math.pow(1 - t, 3); // ease-out cubic
-            this._bgm.volume = startVol + (targetVol - startVol) * ease;
-            if (t < 1) this._duckRafId = requestAnimationFrame(tick);
-        };
-        this._duckRafId = requestAnimationFrame(tick);
+        if (!this.#activeBgmHowl?.playing()) return;
+        this.#activeBgmHowl.fade(this.#activeBgmHowl.volume(), this.#bgmBaseVolume, DUCK_FADE_RESUME_MS);
     }
 
-    _duckBGM() {
-        if (this._bgm.paused) return;
-        cancelAnimationFrame(this._duckRafId);
-        const startVol  = this._bgm.volume;
-        const targetVol = this._bgmBaseVolume * this._duckFactor;
-        const durationMs = 220;
-        const startTime  = performance.now();
+    // ─────────────────────────────────────────────────────────────────────────
+    // DUCKING INTERNO — activado por eventos de voz
+    // ─────────────────────────────────────────────────────────────────────────
 
-        const tick = () => {
-            const t = Math.min((performance.now() - startTime) / durationMs, 1);
-            const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
-            this._bgm.volume = startVol + (targetVol - startVol) * ease;
-            if (t < 1) this._duckRafId = requestAnimationFrame(tick);
-        };
-        this._duckRafId = requestAnimationFrame(tick);
+    #duckBgmForVoice() {
+        if (!this.#activeBgmHowl?.playing()) return;
+        const targetVolume = this.#bgmBaseVolume * BGM_DUCK_FACTOR_VOICE;
+        this.#activeBgmHowl.fade(this.#activeBgmHowl.volume(), targetVolume, DUCK_FADE_VOICE_MS);
     }
 
-    _unduckBGM() {
-        if (this._bgm.paused) return;
-        cancelAnimationFrame(this._duckRafId);
-        const startVol   = this._bgm.volume;
-        const targetVol  = this._bgmBaseVolume;
-        const durationMs = 400;
-        const startTime  = performance.now();
+    #unduckBgmAfterVoice() {
+        if (!this.#activeBgmHowl?.playing()) return;
+        this.#activeBgmHowl.fade(this.#activeBgmHowl.volume(), this.#bgmBaseVolume, DUCK_FADE_RESUME_MS);
+    }
 
-        const tick = () => {
-            const t = Math.min((performance.now() - startTime) / durationMs, 1);
-            const ease = 1 - Math.pow(1 - t, 3); // ease-out cubic
-            this._bgm.volume = startVol + (targetVol - startVol) * ease;
-            if (t < 1) this._duckRafId = requestAnimationFrame(tick);
-        };
-        this._duckRafId = requestAnimationFrame(tick);
+    // ─────────────────────────────────────────────────────────────────────────
+    // UTILIDADES PRIVADAS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Construye el array de URLs de fuente para Howler.
+     * Howler elige automáticamente el primer formato compatible con el navegador.
+     *
+     * @param {string}       trackName
+     * @param {AudioChannel} channel
+     * @returns {string[]}
+     */
+    #buildSourceUrls(trackName, channel) {
+        const basePath = `${AUDIO_CHANNEL_PATHS[channel]}${trackName}`;
+        return SUPPORTED_AUDIO_FORMATS.map(format => `${basePath}.${format}`);
+    }
+
+    /** Detiene el BGM activo sin fade — para reemplazos inmediatos. */
+    #stopBgmImmediately() {
+        if (!this.#activeBgmHowl) return;
+        this.#activeBgmHowl.stop();
+        this.#activeBgmHowl.unload();
+        this.#activeBgmHowl     = null;
+        this.#activeBgmTrackName = null;
     }
 }

--- a/src/modules/MenuSystem.js
+++ b/src/modules/MenuSystem.js
@@ -578,7 +578,7 @@ export class MenuSystem {
         this.#hudClockInterval = null;
     }
 
-    // ── Slots ──────────────────────────────────────────────────────────────
+    // ── Slots ─────────────────────────────────────────────────────────────
 
     async #loadAllSlots() {
         await Promise.all(


### PR DESCRIPTION
## Qué hace este PR
Close #18 

Refactoriza los módulos principales del motor aplicando nombrado expresivo,
typedefs JSDoc, campos privados con `#` y reemplaza HTMLAudioElement por Howler.js.

## Tipo de cambio

- [x] Refactor (sin cambio de comportamiento)

## Archivos modificados

- `Engine.js` — campos privados, `#dispatch`, `#advance`, handlers separados
- `State.js` — typedefs completos, propiedades declaradas, sin comentarios narrativos
- `SaveManager.js` — typedef `SaveSlotId`, nombres expresivos en export/import
- `SceneManager.js` — campos privados, `#fetchAndParseIfNeeded`, `#executeChapterTransition`
- `Character.js` — `#poses` privado, typedef `PoseDefinition`
- `Grammar.js` — JSDoc limpio, ejemplos de sintaxis como comentarios `//`
- `Parser.js` — typedefs `ParseRule` y `ConditionalFrame`, métodos `#matchAllLines` y `#compileConditionalBlocks`
- `db.js` — JSDoc con regla de migración documentada
- `Audio.js` — reescrito con Howler.js: fade nativo, detección de formato automática, ducking por eventos
- `main.js` — `INPUT_COOLDOWN_MS`, `initialState`, `initializeGame`, secciones separadas

## Cómo probarlo

1. Nueva partida — todo el flujo completo
2. BGM con ducking al reproducir voz
3. `pauseDuck` / `pauseUnduck` al abrir y cerrar el menú de pausa
4. Guardar y cargar — estado visual restaurado
5. Skip mode y auto mode
6. goto con `fade:black` entre capítulos

## Checklist

- [x] Probado en Chrome o Firefox
- [ ] Si toca el lenguaje Koedan → `KOEDAN.md` actualizado en este PR
- [ ] Si toca el workflow de assets → `WORKFLOW.md` actualizado en este PR
- [ ] Si añade una tabla o cambia el schema de la DB → versión incrementada en `db.js`
- [x] Los métodos nuevos en `Engine.js` llaman `_nextInternal()`, no `next()`
- [x] Un PR — un cambio (no mezcla features no relacionadas)